### PR TITLE
Added GitHub commit string to version string and output it by default

### DIFF
--- a/build/makefile_common
+++ b/build/makefile_common
@@ -6,7 +6,7 @@ INCFLAGS = -I $(BOOST_INCLUDE)
 
 GIT_VERSION := $(shell git describe --abbrev=7 --dirty --always --tags | sed 's/dirty/mod/g')
 ifeq (,$(GIT_VERSION))
-GIT_VERSION := v1.2.0-release
+GIT_VERSION := v1.2.0
 endif
 C_OPTIONS+=-DVERSION=\"$(GIT_VERSION)\"
 

--- a/build/makefile_common
+++ b/build/makefile_common
@@ -4,7 +4,10 @@ SPLITOBJ = split.o
 
 INCFLAGS = -I $(BOOST_INCLUDE)
 
-GIT_VERSION := $(shell git describe --abbrev=7 --dirty --always --tags 2>/dev/null)
+GIT_VERSION := $(shell git describe --abbrev=7 --dirty --always --tags | sed 's/dirty/mod/g')
+ifeq (,$(GIT_VERSION))
+GIT_VERSION := v1.2.0-release
+endif
 C_OPTIONS+=-DVERSION=\"$(GIT_VERSION)\"
 
 # -pedantic fails on Mac with Boost 1.41 (syntax problems in their headers)

--- a/build/makefile_common
+++ b/build/makefile_common
@@ -4,6 +4,9 @@ SPLITOBJ = split.o
 
 INCFLAGS = -I $(BOOST_INCLUDE)
 
+GIT_VERSION := $(shell git describe --abbrev=7 --dirty --always --tags 2>/dev/null)
+C_OPTIONS+=-DVERSION=\"$(GIT_VERSION)\"
+
 # -pedantic fails on Mac with Boost 1.41 (syntax problems in their headers)
 #CC = ${GPP} ${C_PLATFORM} -ansi -pedantic -Wno-long-long ${C_OPTIONS} $(INCFLAGS)
 CC = ${GPP} ${C_PLATFORM} -ansi -Wno-long-long ${C_OPTIONS} $(INCFLAGS)
@@ -15,7 +18,7 @@ LDFLAGS = -L$(BASE)/lib -L.
 # install libboost_thread-mt, but not
 # libboost_thread (e.g. macOS)
 $(shell echo "int main(){ return 0; }" > linktest.cpp)
-$(shell $(GPP) $(LDFLAGS) -l boost_thread-mt linktest.cpp -o linktest >/dev/null 2>&1)
+$(shell $(CC) $(LDFLAGS) -l boost_thread-mt}${BOOST_LIB_VERSION} linktest.cpp -o linktest >/dev/null 2>&1)
 threadmt:=$(shell if [ -f ./linktest ]; then echo "-mt"; rm ./linktest; fi;)
 $(shell rm ./linktest.cpp)
 

--- a/build/python/setup.py
+++ b/build/python/setup.py
@@ -46,15 +46,26 @@ def in_conda():
 
 def find_version():
     """Extract the current version of these python bindings from the __init__.py file."""
-    try:
-        with open(os.path.join(base_dir, 'vina', '__init__.py')) as fp:
-            for line in fp:
-                version_match = re.match(r'^__version__ = "(.+?)"$', line)
-                if version_match:
-                    return version_match.group(1)
-            raise RuntimeError('Could not find version string in vina/__init__.py.')
-    except IOError:
-        raise RuntimeError('Could not find vina/__init__.py.')
+    git_version = subprocess.check_output(['git', 'describe', '--abbrev=7', '--dirty', '--always', '--tags']).strip().decode()
+
+    if git_version:
+        # Normalize version to follow PEP 440 specifications
+        if git_version.startswith('v'):
+            git_version = git_version[1:]
+        git_version = git_version.replace('dirty', 'mod').replace('-', '+', 1).replace('-', '.')
+        return git_version
+    else:
+        try:
+            with open(os.path.join(base_dir, 'vina', '__init__.py')) as fp:
+                for line in fp:
+                    version_match = re.match(r'^__version__ = "(.+?)"$', line)
+
+                    if version_match:
+                        version = version_match.group(1)
+                        return version
+                raise RuntimeError('Could not find version string in vina/__init__.py.')
+        except IOError:
+            raise RuntimeError('Could not find vina/__init__.py.')
 
 
 def execute_command(cmd_line):

--- a/build/python/setup.py
+++ b/build/python/setup.py
@@ -46,15 +46,16 @@ def in_conda():
 
 def find_version():
     """Extract the current version of these python bindings from the __init__.py file."""
-    git_version = subprocess.check_output(['git', 'describe', '--abbrev=7', '--dirty', '--always', '--tags']).strip().decode()
+    try:
+        git_output = subprocess.check_output(['git', 'describe', '--abbrev=7', '--dirty', '--always', '--tags'])
+        git_output = git_output.strip().decode()
 
-    if git_version:
-        # Normalize version to follow PEP 440 specifications
-        if git_version.startswith('v'):
-            git_version = git_version[1:]
-        git_version = git_version.replace('dirty', 'mod').replace('-', '+', 1).replace('-', '.')
+        if git_output.startswith('v'):
+            git_output = git_output[1:]
+        git_version = git_output.replace('dirty', 'mod').replace('-', '+', 1).replace('-', '.')
+
         return git_version
-    else:
+    except:
         try:
             with open(os.path.join(base_dir, 'vina', '__init__.py')) as fp:
                 for line in fp:

--- a/build/python/vina/__init__.py
+++ b/build/python/vina/__init__.py
@@ -4,7 +4,7 @@
 # Vina
 #
 
-__version__ = "1.2.0.dev3"
+__version__ = "1.2.0"
 
 from .vina import Vina
 

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -65,7 +65,8 @@ void check_occurrence(boost::program_options::variables_map& vm, boost::program_
 
 int main(int argc, char* argv[]) {
 	using namespace boost::program_options;
-	const std::string version_string = "AutoDock Vina 1.2.0.dev3 (March 1, 2021)";
+	const std::string git_version = VERSION;
+	const std::string version_string = "AutoDock Vina " + git_version;
 	const std::string error_message = "\n\n\
 Please report bugs through the Issue Tracker on GitHub \n\
 (https://github.com/ccsb-scripps/AutoDock-Vina/issues)., so\n\
@@ -246,6 +247,7 @@ Thank you!\n";
 		desc_config.add(inputs).add(search_area).add(outputs).add(advanced).add(misc);
 		desc_simple.add(inputs).add(search_area).add(outputs).add(misc).add(config).add(info);
 
+		std::cout << version_string << '\n';
 		try {
 			//store(parse_command_line(argc, argv, desc, command_line_style::default_style ^ command_line_style::allow_guessing), vm);
 			store(command_line_parser(argc, argv)
@@ -284,7 +286,6 @@ Thank you!\n";
 		}
 
 		if (version) {
-			std::cout << version_string << '\n';
 			return 0;
 		}
 

--- a/src/split/split.cpp
+++ b/src/split/split.cpp
@@ -132,7 +132,8 @@ void write_multimodel_pdbqt(const models& m, const std::string& ligand_prefix, c
 int main(int argc, char* argv[]) {
 	using namespace boost::program_options;
 	const bool advanced = false;
-	const std::string version_string = "AutoDock Vina PDBQT Split 1.1.2 (May 11, 2011)";
+	const std::string git_version = VERSION;
+	const std::string version_string = "AutoDock Vina PDBQT Split " + git_version;
 
 	const std::string error_message = "\n\n\
 Please contact the author, Dr. Oleg Trott <ot14@columbia.edu>, so\n\
@@ -167,6 +168,7 @@ Thank you!\n";
 		options_description desc;
 		desc.add(inputs).add(outputs).add(info);
 
+		std::cout << version_string << '\n';
 		positional_options_description positional; // remains empty
 		variables_map vm;
 		try {
@@ -187,7 +189,6 @@ Thank you!\n";
 			return 0;
 		}
 		if(version) {
-			std::cout << version_string << '\n';
 			return 0;
 		}
 


### PR DESCRIPTION
This PR adds the abbreviated Git version string to the program version and outputs it by default. 

Additionally, a small fix to makefile_common to make the test for the possible libboost-thread-mt library a bit more robust is also added.

I tested it on one of our Linux nodes with it working well.