### PR TITLE
Added new AutoDock-Vina citation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,5 @@ AutoDock Vina is distributed under the Apache License, Version 2.0.
 The installation instructions, documentation and tutorials can be found on [readthedocs.org](https://autodock-vina.readthedocs.io/en/latest/).
 
 ## Citations
-* Trott, O., & Olson, A. J. (2010). AutoDock Vina: improving the speed and accuracy of docking with a new scoring function, efficient optimization, and multithreading. Journal of computational chemistry, 31(2), 455-461.
+* J. Eberhardt, D. Santos-Martins, A. F. Tillack, and S. Forli. (2021). AutoDock Vina 1.2.0: New Docking Methods, Expanded Force Field, and Python Bindings, Journal of Chemical Information and Modeling. 
+* O. Trott & A. J. Olson. (2010). AutoDock Vina: improving the speed and accuracy of docking with a new scoring function, efficient optimization, and multithreading. Journal of computational chemistry, 31(2), 455-461.

--- a/README.md
+++ b/README.md
@@ -21,5 +21,5 @@ AutoDock Vina is distributed under the Apache License, Version 2.0.
 The installation instructions, documentation and tutorials can be found on [readthedocs.org](https://autodock-vina.readthedocs.io/en/latest/).
 
 ## Citations
-* J. Eberhardt, D. Santos-Martins, A. F. Tillack, and S. Forli. (2021). AutoDock Vina 1.2.0: New Docking Methods, Expanded Force Field, and Python Bindings, Journal of Chemical Information and Modeling. 
-* O. Trott & A. J. Olson. (2010). AutoDock Vina: improving the speed and accuracy of docking with a new scoring function, efficient optimization, and multithreading. Journal of computational chemistry, 31(2), 455-461.
+* J. Eberhardt, D. Santos-Martins, A. F. Tillack, and S. Forli. (2021). AutoDock Vina 1.2.0: New Docking Methods, Expanded Force Field, and Python Bindings. Journal of Chemical Information and Modeling. 
+* O. Trott and A. J. Olson. (2010). AutoDock Vina: improving the speed and accuracy of docking with a new scoring function, efficient optimization, and multithreading. Journal of computational chemistry, 31(2), 455-461.

--- a/build/makefile_common
+++ b/build/makefile_common
@@ -21,7 +21,7 @@ LDFLAGS = -L$(BASE)/lib -L.
 # install libboost_thread-mt, but not
 # libboost_thread (e.g. macOS)
 $(shell echo "int main(){ return 0; }" > linktest.cpp)
-$(shell $(CC) $(LDFLAGS) -l boost_thread-mt}${BOOST_LIB_VERSION} linktest.cpp -o linktest >/dev/null 2>&1)
+$(shell $(CC) $(LDFLAGS) -l boost_thread-mt${BOOST_LIB_VERSION} linktest.cpp -o linktest >/dev/null 2>&1)
 threadmt:=$(shell if [ -f ./linktest ]; then echo "-mt"; rm ./linktest; fi;)
 $(shell rm ./linktest.cpp)
 

--- a/docs/source/citations.rst
+++ b/docs/source/citations.rst
@@ -6,7 +6,7 @@ AutoDock Vina
 
 AutoDock Vina is a scientific software that is described in academics publications. Please cite these papers when you used AutoDock Vina in your work:
 
-- Santos-Martins, D., Eberhardt, J., Tillack, A.F., Forli, S. (2020). AutoDock Vina 1.2.0. Improved software with new docking methods, expanded force field, and Python bindings.
+- Eberhardt, J., Santos-Martins, D.,  Tillack, A.F., Forli, S. (2021). AutoDock Vina 1.2.0: New Docking Methods, Expanded Force Field, and Python Bindings. Journal of Chemical Information and Modeling.
 - Trott, O., & Olson, A. J. (2010). AutoDock Vina: improving the speed and accuracy of docking with a new scoring function, efficient optimization, and multithreading. Journal of computational chemistry, 31(2), 455-461.
 
 Related publications

--- a/src/lib/vina.cpp
+++ b/src/lib/vina.cpp
@@ -30,15 +30,19 @@ void Vina::cite() {
 #################################################################\n\
 # If you used AutoDock Vina in your work, please cite:          #\n\
 #                                                               #\n\
+# J. Eberhardt, D. Santos-Martins, A. F. Tillack, and S. Forli  #\n\
+# AutoDock Vina 1.2.0: New Docking Methods, Expanded Force      #\n\
+# Field, and Python Bindings, J. Chem. Inf. Model. (2021)       #\n\
+# DOI 10.1021/acs.jcim.1c00203                                  #\n\
+#                                                               #\n\
 # O. Trott, A. J. Olson,                                        #\n\
 # AutoDock Vina: improving the speed and accuracy of docking    #\n\
 # with a new scoring function, efficient optimization and       #\n\
-# multithreading, Journal of Computational Chemistry 31 (2010)  #\n\
-# 455-461                                                       #\n\
-#                                                               #\n\
+# multithreading, J. Comp. Chem. (2010)                         #\n\
 # DOI 10.1002/jcc.21334                                         #\n\
 #                                                               #\n\
-# Please see http://vina.scripps.edu for more information.      #\n\
+# Please see https://github.com/ccsb-scripps/AutoDock-Vina for  #\n\
+# more information.                                             #\n\
 #################################################################\n";
 
 	std::cout << cite_message << '\n';

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -91,15 +91,19 @@ Thank you!\n";
 #################################################################\n\
 # If you used AutoDock Vina in your work, please cite:          #\n\
 #                                                               #\n\
+# J. Eberhardt, D. Santos-Martins, A. F. Tillack, and S. Forli  #\n\
+# AutoDock Vina 1.2.0: New Docking Methods, Expanded Force      #\n\
+# Field, and Python Bindings, J. Chem. Inf. Model. (2021)       #\n\
+# DOI 10.1021/acs.jcim.1c00203                                  #\n\
+#                                                               #\n\
 # O. Trott, A. J. Olson,                                        #\n\
 # AutoDock Vina: improving the speed and accuracy of docking    #\n\
 # with a new scoring function, efficient optimization and       #\n\
-# multithreading, Journal of Computational Chemistry 31 (2010)  #\n\
-# 455-461                                                       #\n\
-#                                                               #\n\
+# multithreading, J. Comp. Chem. (2010)                         #\n\
 # DOI 10.1002/jcc.21334                                         #\n\
 #                                                               #\n\
-# Please see http://vina.scripps.edu for more information.      #\n\
+# Please see https://github.com/ccsb-scripps/AutoDock-Vina for  #\n\
+# more information.                                             #\n\
 #################################################################\n";
 
 	try {


### PR DESCRIPTION
This PR adds the new AutoDock-Vina citation. The new citation will appear when executing the vina binary, python bindings and also in the readthedocs documentation.

Removed also an extra bracket in the makefile_common when looking for libboost-thread-mt library (mac OS only).