### PR TITLE
Improved documentation

### DIFF
--- a/docs/source/docking_basic.rst
+++ b/docs/source/docking_basic.rst
@@ -13,10 +13,16 @@ Let's start with our first example of docking, where the typical usage pattern w
 
     - Forli, S., Huey, R., Pique, M. E., Sanner, M. F., Goodsell, D. S., & Olson, A. J. (2016). Computational protein–ligand docking and virtual drug screening with the AutoDock suite. Nature protocols, 11(5), 905-919.
 
+Materials for this tutorial
+---------------------------
+
+For this tutorial, all the basic material will be provided and can be found in the ``AutoDock-Vina/example/basic_docking/data`` directory (or on `GitHub <https://github.com/ccsb-scripps/AutoDock-Vina/tree/develop/example/basic_docking>`_). If you ever feel lost, you can always take a look at the solution here: ``AutoDock-Vina/example/basic_docking/solution``. All the Python scripts used here (except for ``prepare_receptor`` and ``mk_prepare_ligand.py``) are located in the ``AutoDock-Vina/example/autodock_scripts`` directory, alternatively you can also find them here on `GitHub <https://github.com/ccsb-scripps/AutoDock-Vina/tree/develop/example/autodock_scripts>`_.
+
+
 1. Preparing the receptor
 -------------------------
 
-During this step, we will create a PDBQT file of our receptor containing only the polar hydrogen atoms as well as partial charges. For this step, we will use the ``prepare_receptor`` command tool from the ADFR Suite. As a prerequisite, a receptor coordinate file must contain all hydrogen atoms. If hydrogen atoms are absent in the protein structure file, you can add the ``-A "hydrogens"`` flag. Many tools exist to add missing hydrogen atoms to a protein, one popular choice would be to use `REDUCE <http://kinemage.biochem.duke.edu/software/reduce.php>`_. If you are using experimental structures (for instance, from the `Protein Data Bank <https://www.rcsb.org>`_), use a text editor to remove waters, ligands, cofactors, ions deemed unnecessary for the docking. The file ``1iep_receptorH.pdb`` is provided (see ``<autodock-vina_directory>/example/basic_docking/data`` directory). This file contains the receptor coordinates taken from PDB entry `1iep <https://www.rcsb.org/structure/1IEP>`_.
+During this step, we will create a PDBQT file of our receptor containing only the polar hydrogen atoms as well as partial charges. For this step, we will use the ``prepare_receptor`` command tool from the ADFR Suite. As a prerequisite, a receptor coordinate file must contain all hydrogen atoms. If hydrogen atoms are absent in the protein structure file, you can add the ``-A "hydrogens"`` flag. Many tools exist to add missing hydrogen atoms to a protein, one popular choice would be to use `REDUCE <http://kinemage.biochem.duke.edu/software/reduce.php>`_. If you are using experimental structures (for instance, from the `Protein Data Bank <https://www.rcsb.org>`_), use a text editor to remove waters, ligands, cofactors, ions deemed unnecessary for the docking. This file contains the receptor coordinates taken from PDB entry `1iep <https://www.rcsb.org/structure/1IEP>`_.
 
 .. code-block:: bash
 
@@ -46,7 +52,7 @@ Other options are available for ``mk_prepare_ligand.py`` by typing ``mk_prepare_
 
 Now, we have to define the grid space for the docking, typically, a 3D box around a the potential binding site of a receptor. During this step, we will create the input file for AutoGrid4, which will create an affinity map file for each atom types. The grid parameter file specifies an AutoGrid4 calculation, including the size and location of the grid, the atom types that will be used, the coordinate file for the rigid receptor, and other parameters for calculation of the grids.
 
-To prepare the gpf file for AutoGrid4, your can use the ``prepare_gpf.py`` command line tool. This Python script is available here: ``<autodock-vina_directory>/example/autodock_scripts``.
+To prepare the gpf file for AutoGrid4, your can use the ``prepare_gpf.py`` command line tool.
 
 .. code-block:: bash
 

--- a/docs/source/docking_basic.rst
+++ b/docs/source/docking_basic.rst
@@ -16,7 +16,7 @@ Let's start with our first example of docking, where the typical usage pattern w
 Materials for this tutorial
 ---------------------------
 
-For this tutorial, all the basic material will be provided and can be found in the ``AutoDock-Vina/example/basic_docking/data`` directory (or on `GitHub <https://github.com/ccsb-scripps/AutoDock-Vina/tree/develop/example/basic_docking>`_). If you ever feel lost, you can always take a look at the solution here: ``AutoDock-Vina/example/basic_docking/solution``. All the Python scripts used here (except for ``prepare_receptor`` and ``mk_prepare_ligand.py``) are located in the ``AutoDock-Vina/example/autodock_scripts`` directory, alternatively you can also find them here on `GitHub <https://github.com/ccsb-scripps/AutoDock-Vina/tree/develop/example/autodock_scripts>`_.
+For this tutorial, all the basic material are provided and can be found in the ``AutoDock-Vina/example/basic_docking/data`` directory (or on `GitHub <https://github.com/ccsb-scripps/AutoDock-Vina/tree/develop/example/basic_docking>`_). If you ever feel lost, you can always take a look at the solution here: ``AutoDock-Vina/example/basic_docking/solution``. All the Python scripts used here (except for ``prepare_receptor`` and ``mk_prepare_ligand.py``) are located in the ``AutoDock-Vina/example/autodock_scripts`` directory, alternatively you can also find them here on `GitHub <https://github.com/ccsb-scripps/AutoDock-Vina/tree/develop/example/autodock_scripts>`_.
 
 
 1. Preparing the receptor
@@ -52,7 +52,7 @@ Other options are available for ``mk_prepare_ligand.py`` by typing ``mk_prepare_
 
 Now, we have to define the grid space for the docking, typically, a 3D box around a the potential binding site of a receptor. During this step, we will create the input file for AutoGrid4, which will create an affinity map file for each atom types. The grid parameter file specifies an AutoGrid4 calculation, including the size and location of the grid, the atom types that will be used, the coordinate file for the rigid receptor, and other parameters for calculation of the grids.
 
-To prepare the gpf file for AutoGrid4, your can use the ``prepare_gpf.py`` command line tool.
+To prepare the gpf file for AutoGrid4, you can use the ``prepare_gpf.py`` command line tool.
 
 .. code-block:: bash
 

--- a/docs/source/docking_flexible.rst
+++ b/docs/source/docking_flexible.rst
@@ -16,7 +16,7 @@ The lack of receptor flexibility is arguably the greatest limitation in these ty
 Materials for this tutorial
 ---------------------------
 
-For this tutorial, all the basic material will be provided and can be found in the ``AutoDock-Vina/example/flexible_docking/data`` directory (or on `GitHub <https://github.com/ccsb-scripps/AutoDock-Vina/tree/develop/example/flexible_docking>`_). If you ever feel lost, you can always take a look at the solution here: ``AutoDock-Vina/example/flexible_docking/solution``. All the Python scripts used here (except for ``prepare_receptor`` and ``mk_prepare_ligand.py``) are located in the ``AutoDock-Vina/example/autodock_scripts`` directory, alternatively you can also find them here on `GitHub <https://github.com/ccsb-scripps/AutoDock-Vina/tree/develop/example/autodock_scripts>`_.
+For this tutorial, all the basic material are provided and can be found in the ``AutoDock-Vina/example/flexible_docking/data`` directory (or on `GitHub <https://github.com/ccsb-scripps/AutoDock-Vina/tree/develop/example/flexible_docking>`_). If you ever feel lost, you can always take a look at the solution here: ``AutoDock-Vina/example/flexible_docking/solution``. All the Python scripts used here (except for ``prepare_receptor`` and ``mk_prepare_ligand.py``) are located in the ``AutoDock-Vina/example/autodock_scripts`` directory, alternatively you can also find them here on `GitHub <https://github.com/ccsb-scripps/AutoDock-Vina/tree/develop/example/autodock_scripts>`_.
 
 1. Preparing the flexible receptor
 ----------------------------------

--- a/docs/source/docking_flexible.rst
+++ b/docs/source/docking_flexible.rst
@@ -13,10 +13,15 @@ The lack of receptor flexibility is arguably the greatest limitation in these ty
 
     - Forli, S., Huey, R., Pique, M. E., Sanner, M. F., Goodsell, D. S., & Olson, A. J. (2016). Computational protein–ligand docking and virtual drug screening with the AutoDock suite. Nature protocols, 11(5), 905-919.
 
+Materials for this tutorial
+---------------------------
+
+For this tutorial, all the basic material will be provided and can be found in the ``AutoDock-Vina/example/flexible_docking/data`` directory (or on `GitHub <https://github.com/ccsb-scripps/AutoDock-Vina/tree/develop/example/flexible_docking>`_). If you ever feel lost, you can always take a look at the solution here: ``AutoDock-Vina/example/flexible_docking/solution``. All the Python scripts used here (except for ``prepare_receptor`` and ``mk_prepare_ligand.py``) are located in the ``AutoDock-Vina/example/autodock_scripts`` directory, alternatively you can also find them here on `GitHub <https://github.com/ccsb-scripps/AutoDock-Vina/tree/develop/example/autodock_scripts>`_.
+
 1. Preparing the flexible receptor
 ----------------------------------
 
-During this step, we are going to split the receptor coordinates into two PDBQT files: one for the rigid portion and one for the flexible side chains. As with the :ref:`basic_docking` tutorial, the method requires a receptor coordinate file that includes all hydrogen atoms. The file ``1fpu_receptorH.pdb`` is provided (see ``<autodock-vina_directory>/example/flexible_docking/data`` directory). This file contains the receptor coordinates taken from PDB entry ``1fpu``. The Python script ``prepare_flexreceptor.py`` is available here: ``<autodock-vina_directory>/example/autodock_scripts``.
+During this step, we are going to split the receptor coordinates into two PDBQT files: one for the rigid portion and one for the flexible side chains. As with the :ref:`basic_docking` tutorial, the method requires a receptor coordinate file that includes all hydrogen atoms. The file ``1fpu_receptorH.pdb`` is provided (see ``<autodock-vina_directory>/example/flexible_docking/data`` directory). It contains the receptor coordinates taken from PDB entry ``1fpu``.
 
 .. code-block:: bash
     

--- a/docs/source/docking_hydrated.rst
+++ b/docs/source/docking_hydrated.rst
@@ -27,7 +27,7 @@ In this tutorial, we are going to dock a fragment-size ligand (nicotine) with ex
 Materials for this tutorial
 ---------------------------
 
-For this tutorial, all the basic material will be provided and can be found in the ``AutoDock-Vina/example/hydrated_docking/data`` directory (or on `GitHub <https://github.com/ccsb-scripps/AutoDock-Vina/tree/develop/example/hydrated_docking>`_). If you ever feel lost, you can always take a look at the solution here: ``AutoDock-Vina/example/hydrated_docking/solution``. All the Python scripts used here (except for ``prepare_receptor`` and ``mk_prepare_ligand.py``) are located in the ``AutoDock-Vina/example/autodock_scripts`` directory, alternatively you can also find them here on `GitHub <https://github.com/ccsb-scripps/AutoDock-Vina/tree/develop/example/autodock_scripts>`_.
+For this tutorial, all the basic material are provided and can be found in the ``AutoDock-Vina/example/hydrated_docking/data`` directory (or on `GitHub <https://github.com/ccsb-scripps/AutoDock-Vina/tree/develop/example/hydrated_docking>`_). If you ever feel lost, you can always take a look at the solution here: ``AutoDock-Vina/example/hydrated_docking/solution``. All the Python scripts used here (except for ``prepare_receptor`` and ``mk_prepare_ligand.py``) are located in the ``AutoDock-Vina/example/autodock_scripts`` directory, alternatively you can also find them here on `GitHub <https://github.com/ccsb-scripps/AutoDock-Vina/tree/develop/example/autodock_scripts>`_.
 
 1. Preparing the receptor
 -------------------------

--- a/docs/source/docking_hydrated.rst
+++ b/docs/source/docking_hydrated.rst
@@ -24,6 +24,11 @@ In this tutorial, we are going to dock a fragment-size ligand (nicotine) with ex
     - Forli, S., & Olson, A. J. (2012). A force field with discrete displaceable waters and desolvation entropy for hydrated ligand docking. Journal of medicinal chemistry, 55(2), 623-638.
     - Forli, S., Huey, R., Pique, M. E., Sanner, M. F., Goodsell, D. S., & Olson, A. J. (2016). Computational protein–ligand docking and virtual drug screening with the AutoDock suite. Nature protocols, 11(5), 905-919.
 
+Materials for this tutorial
+---------------------------
+
+For this tutorial, all the basic material will be provided and can be found in the ``AutoDock-Vina/example/hydrated_docking/data`` directory (or on `GitHub <https://github.com/ccsb-scripps/AutoDock-Vina/tree/develop/example/hydrated_docking>`_). If you ever feel lost, you can always take a look at the solution here: ``AutoDock-Vina/example/hydrated_docking/solution``. All the Python scripts used here (except for ``prepare_receptor`` and ``mk_prepare_ligand.py``) are located in the ``AutoDock-Vina/example/autodock_scripts`` directory, alternatively you can also find them here on `GitHub <https://github.com/ccsb-scripps/AutoDock-Vina/tree/develop/example/autodock_scripts>`_.
+
 1. Preparing the receptor
 -------------------------
 
@@ -88,7 +93,7 @@ You can now execute ``autogrid4`` using the GPF file called ``1uw6_receptor.gpf`
 .. code-block:: bash
 
     $ autogrid4 -p 1uw6_receptor.gpf -l 1uw6_receptor.glg
-    $ pythonsh <script_directory>/mapwater.py -r 1uw6_receptor.pdbqt -s 1uw6_receptor.W.map
+    $ python <script_directory>/mapwater.py -r 1uw6_receptor.pdbqt -s 1uw6_receptor.W.map
 
 For more informations about the ``mapwater.py`` command tool and all the available options, just type ``mapwater.py``. After executing this command, you should obtain a new affinity map called ``1uw6_receptor.W.map`` and the following the output:
 
@@ -177,7 +182,7 @@ Docking results are filtered by using the receptor to remove displaced waters an
 
 .. code-block:: bash
 
-    $ pythonsh <script_directory>/dry.py -r 1uw6_receptor.pdbqt -m 1uw6_receptor.W.map -i 1uw6_ligand_ad4_out.pdbqt
+    $ python <script_directory>/dry.py -r 1uw6_receptor.pdbqt -m 1uw6_receptor.W.map -i 1uw6_ligand_ad4_out.pdbqt
 
 For more informations about the ``dry.py`` command tool and all the available options, just type ``dry.py``. Running the previous command should give you this output:
 

--- a/docs/source/docking_macrocycle.rst
+++ b/docs/source/docking_macrocycle.rst
@@ -25,7 +25,7 @@ For this tutorial, we are going to use the dataset from the Drug Design Data Res
 Materials for this tutorial
 ---------------------------
 
-For this tutorial, all the basic material will be provided and can be found in the ``AutoDock-Vina/example/docking_with_macrocycles/data`` directory (or on `GitHub <https://github.com/ccsb-scripps/AutoDock-Vina/tree/develop/example/docking_with_macrocycles>`_). If you ever feel lost, you can always take a look at the solution here: ``AutoDock-Vina/example/docking_with_macrocycles/solution``. All the Python scripts used here (except for ``prepare_receptor`` and ``mk_prepare_ligand.py``) are located in the ``AutoDock-Vina/example/autodock_scripts`` directory, alternatively you can also find them here on `GitHub <https://github.com/ccsb-scripps/AutoDock-Vina/tree/develop/example/autodock_scripts>`_.
+For this tutorial, all the basic material are provided and can be found in the ``AutoDock-Vina/example/docking_with_macrocycles/data`` directory (or on `GitHub <https://github.com/ccsb-scripps/AutoDock-Vina/tree/develop/example/docking_with_macrocycles>`_). If you ever feel lost, you can always take a look at the solution here: ``AutoDock-Vina/example/docking_with_macrocycles/solution``. All the Python scripts used here (except for ``prepare_receptor`` and ``mk_prepare_ligand.py``) are located in the ``AutoDock-Vina/example/autodock_scripts`` directory, alternatively you can also find them here on `GitHub <https://github.com/ccsb-scripps/AutoDock-Vina/tree/develop/example/autodock_scripts>`_.
 
 1. Preparing the receptor
 -------------------------

--- a/docs/source/docking_macrocycle.rst
+++ b/docs/source/docking_macrocycle.rst
@@ -22,6 +22,10 @@ The current implementation is described in our paper on the D3R Grand Challenge 
 
 For this tutorial, we are going to use the dataset from the Drug Design Data Resource (D3R) Grand Challenge 4 (GC4) organized in 2018. For more information about the D3R organization and it role in the computer-aided drug discovery community: `https://drugdesigndata.org <https://drugdesigndata.org/>`_. In second stage (1b) of this challenge, participants were asked to predict the bound poses of 20 BACE1 ligands knowing the crystallographic structure of the protein. A macrocycle is present in 19 out of 20 ligands, making pose predictions particularly challenging for the reasons described earlier. The docking procedure being the same for all 20 ligands, we are going to redock only one of the macrocycle in this tutorial.
 
+Materials for this tutorial
+---------------------------
+
+For this tutorial, all the basic material will be provided and can be found in the ``AutoDock-Vina/example/docking_with_macrocycles/data`` directory (or on `GitHub <https://github.com/ccsb-scripps/AutoDock-Vina/tree/develop/example/docking_with_macrocycles>`_). If you ever feel lost, you can always take a look at the solution here: ``AutoDock-Vina/example/docking_with_macrocycles/solution``. All the Python scripts used here (except for ``prepare_receptor`` and ``mk_prepare_ligand.py``) are located in the ``AutoDock-Vina/example/autodock_scripts`` directory, alternatively you can also find them here on `GitHub <https://github.com/ccsb-scripps/AutoDock-Vina/tree/develop/example/autodock_scripts>`_.
 
 1. Preparing the receptor
 -------------------------

--- a/docs/source/docking_multiple_ligands.rst
+++ b/docs/source/docking_multiple_ligands.rst
@@ -13,7 +13,7 @@ The protein PDE in complex with two inhibitors (pdb id: `5x72 <https://www.rcsb.
 Materials for this tutorial
 ---------------------------
 
-For this tutorial, all the basic material will be provided and can be found in the ``AutoDock-Vina/example/mulitple_ligands_docking/data`` directory (or on `GitHub <https://github.com/ccsb-scripps/AutoDock-Vina/tree/develop/example/mulitple_ligands_docking>`_). If you ever feel lost, you can always take a look at the solution here: ``AutoDock-Vina/example/mulitple_ligands_docking/solution``. All the Python scripts used here (except for ``prepare_receptor`` and ``mk_prepare_ligand.py``) are located in the ``AutoDock-Vina/example/autodock_scripts`` directory, alternatively you can also find them here on `GitHub <https://github.com/ccsb-scripps/AutoDock-Vina/tree/develop/example/autodock_scripts>`_.
+For this tutorial, all the basic material are provided and can be found in the ``AutoDock-Vina/example/mulitple_ligands_docking/data`` directory (or on `GitHub <https://github.com/ccsb-scripps/AutoDock-Vina/tree/develop/example/mulitple_ligands_docking>`_). If you ever feel lost, you can always take a look at the solution here: ``AutoDock-Vina/example/mulitple_ligands_docking/solution``. All the Python scripts used here (except for ``prepare_receptor`` and ``mk_prepare_ligand.py``) are located in the ``AutoDock-Vina/example/autodock_scripts`` directory, alternatively you can also find them here on `GitHub <https://github.com/ccsb-scripps/AutoDock-Vina/tree/develop/example/autodock_scripts>`_.
 
 1. Preparing the flexible receptor
 ----------------------------------
@@ -29,7 +29,7 @@ If you are not sure about this step, the output PDBQT file ``5x72_receptor.pdbqt
 2. Prepare ligands
 ------------------
 
-This time, we will prepare two ligands instead of only one. We will start from the SDF files ``5x72_ligand_p59.sdf`` and ``5x72_ligand_p69.sdf`` located in the ``data`` directory. They were also obtained directly from the `PDB <https://www.rcsb.org>`_ here: `5x72 <https://www.rcsb.org/structure/5X72>`_ (see ``Download instance Coordinates`` link for the P59 and P69 molecules). Since the ligand files do not include the hydrogen atoms, we are going to automatically add them.
+Here, we will prepare two ligands instead of only one. We will start from the SDF files ``5x72_ligand_p59.sdf`` and ``5x72_ligand_p69.sdf`` located in the ``data`` directory. They were also obtained directly from the `PDB <https://www.rcsb.org>`_ here: `5x72 <https://www.rcsb.org/structure/5X72>`_ (see ``Download instance Coordinates`` link for the P59 and P69 molecules). Since the ligand files do not include the hydrogen atoms, we are going to automatically add them.
 
 .. warning::
   
@@ -45,7 +45,7 @@ The output PDBQT ``5x72_ligand_p59.pdbqt`` and ``5x72_ligand_p69.pdbqt`` can be 
 3. (Optional) Generating affinity maps for AutoDock FF
 ------------------------------------------------------
 
-As well as for the docking with a fully rigid receptor, we need to generate a GPF file to precalculate the affinity map for each atom types. However, instead of using the full receptor, affinity maps will be calculated only for the rigid part of the receptor (``5x72_receptor.pdbqt``).
+As well as for the docking with a fully rigid receptor, we need to generate a GPF file to precalculate the affinity maps for each atom type. However, instead of using the full receptor, affinity maps will be calculated only for the rigid part of the receptor (``5x72_receptor.pdbqt``).
 
 To prepare the GPF file for the rigid part of the receptor:
 

--- a/docs/source/docking_multiple_ligands.rst
+++ b/docs/source/docking_multiple_ligands.rst
@@ -10,6 +10,10 @@ The protein PDE in complex with two inhibitors (pdb id: `5x72 <https://www.rcsb.
 .. note::
     This tutorial requires a certain degree of familiarity with the command-line interface. Also, we assume that you installed the ADFR software suite as well as the meeko Python package.
 
+Materials for this tutorial
+---------------------------
+
+For this tutorial, all the basic material will be provided and can be found in the ``AutoDock-Vina/example/mulitple_ligands_docking/data`` directory (or on `GitHub <https://github.com/ccsb-scripps/AutoDock-Vina/tree/develop/example/mulitple_ligands_docking>`_). If you ever feel lost, you can always take a look at the solution here: ``AutoDock-Vina/example/mulitple_ligands_docking/solution``. All the Python scripts used here (except for ``prepare_receptor`` and ``mk_prepare_ligand.py``) are located in the ``AutoDock-Vina/example/autodock_scripts`` directory, alternatively you can also find them here on `GitHub <https://github.com/ccsb-scripps/AutoDock-Vina/tree/develop/example/autodock_scripts>`_.
 
 1. Preparing the flexible receptor
 ----------------------------------
@@ -41,7 +45,7 @@ The output PDBQT ``5x72_ligand_p59.pdbqt`` and ``5x72_ligand_p69.pdbqt`` can be 
 3. (Optional) Generating affinity maps for AutoDock FF
 ------------------------------------------------------
 
-As well as for the docking with a fully rigid receptor, we need to generate a GPF file to precalculate the affinity map for each atom types. However, instead of using the full receptor, affinity maps will be calculated only for the rigid part of the receptor (``5x72_receptor.pdbqt``). The Python script ``prepare_gpf.py`` is available here: ``<autodock-vina_directory>/example/autodock_scripts``.
+As well as for the docking with a fully rigid receptor, we need to generate a GPF file to precalculate the affinity map for each atom types. However, instead of using the full receptor, affinity maps will be calculated only for the rigid part of the receptor (``5x72_receptor.pdbqt``).
 
 To prepare the GPF file for the rigid part of the receptor:
 
@@ -50,7 +54,7 @@ To prepare the GPF file for the rigid part of the receptor:
     $ pythonsh <script_directory>/prepare_gpf.py -l 5x72_ligand_p59.pdbqt -r 5x72_receptor.pdbqt \ 
                -p npts='80,64,64' -p gridcenter='-15 15 129' -o 5x72_receptor.gpf
 
-This time we manually specified the center of the grid ``-p gridcenter='-15 15 129'`` as well as its size ``-p npts='80,64,64'``. The python script ``prepare_gpf.py`` is located in the ``scripts`` directory for the :ref:`basic_docking` tutorial.
+This time we manually specified the center of the grid ``-p gridcenter='-15 15 129'`` as well as its size ``-p npts='80,64,64'``.
 
 .. code-block:: console
     :caption: Content of the grid parameter file (**5x72_receptor.gpf**) for the receptor (**5x72_receptor.pdbqt**)

--- a/docs/source/docking_python.rst
+++ b/docs/source/docking_python.rst
@@ -6,7 +6,7 @@ Python scripting
 Materials for this tutorial
 ---------------------------
 
-For this tutorial, all the basic material will be provided and can be found in the ``AutoDock-Vina/example/python_scripting`` directory (or on `GitHub <https://github.com/ccsb-scripps/AutoDock-Vina/tree/develop/example/python_scripting>`_).
+For this tutorial, all the basic material are provided and can be found in the ``AutoDock-Vina/example/python_scripting`` directory (or on `GitHub <https://github.com/ccsb-scripps/AutoDock-Vina/tree/develop/example/python_scripting>`_).
 
 First example
 -------------

--- a/docs/source/docking_python.rst
+++ b/docs/source/docking_python.rst
@@ -3,6 +3,11 @@
 Python scripting
 ================
 
+Materials for this tutorial
+---------------------------
+
+For this tutorial, all the basic material will be provided and can be found in the ``AutoDock-Vina/example/python_scripting`` directory (or on `GitHub <https://github.com/ccsb-scripps/AutoDock-Vina/tree/develop/example/python_scripting>`_).
+
 First example
 -------------
 

--- a/docs/source/docking_zinc.rst
+++ b/docs/source/docking_zinc.rst
@@ -16,10 +16,15 @@ The AutoDock4 force field was extended to include a specialized potential descri
 
     - Santos-Martins, D., Forli, S., Ramos, M. J., & Olson, A. J. (2014). AutoDock4Zn: an improved AutoDock force field for small-molecule docking to zinc metalloproteins. Journal of chemical information and modeling, 54(8), 2371-2379.
 
+Materials for this tutorial
+---------------------------
+
+For this tutorial, all the basic material will be provided and can be found in the ``AutoDock-Vina/example/docking_with_zinc_metalloproteins/data`` directory (or on `GitHub <https://github.com/ccsb-scripps/AutoDock-Vina/tree/develop/example/docking_with_zinc_metalloproteins>`_). If you ever feel lost, you can always take a look at the solution here: ``AutoDock-Vina/example/docking_with_zinc_metalloproteins/solution``. All the Python scripts used here (except for ``prepare_receptor`` and ``mk_prepare_ligand.py``) are located in the ``AutoDock-Vina/example/autodock_scripts`` directory, alternatively you can also find them here on `GitHub <https://github.com/ccsb-scripps/AutoDock-Vina/tree/develop/example/autodock_scripts>`_.
+
 1. Preparing the receptor
 -------------------------
 
-During this step we will create the PDBQT file of the receptor using the PDB file called ``proteinH.pdb``, containing all the hydrogen atoms, and add the tetrahedral zinc pseudo atoms (``TZ``) around the Zinc ion. TZ atoms represent the preferred position for tetrahedral coordination by the ligand. All the materials for this tutorial can be found here: ``<autodock-vina_directory>/example/docking_with_zinc_metalloproteins/data``. This file contains the receptor coordinates of chain A and B taken from the PDB entry `1s63 <https://www.rcsb.org/structure/1S63>`_. The Python script ``zinc_pseudo.py`` is available here: ``<autodock-vina_directory>/example/autodock_scripts``.
+During this step we will create the PDBQT file of the receptor using the PDB file called ``proteinH.pdb``, containing all the hydrogen atoms, and add the tetrahedral zinc pseudo atoms (``TZ``) around the Zinc ion. TZ atoms represent the preferred position for tetrahedral coordination by the ligand. This file contains the receptor coordinates of chain A and B taken from the PDB entry `1s63 <https://www.rcsb.org/structure/1S63>`_.
 
 To prepare the receptor, execute the following command lines:
 

--- a/docs/source/docking_zinc.rst
+++ b/docs/source/docking_zinc.rst
@@ -19,12 +19,12 @@ The AutoDock4 force field was extended to include a specialized potential descri
 Materials for this tutorial
 ---------------------------
 
-For this tutorial, all the basic material will be provided and can be found in the ``AutoDock-Vina/example/docking_with_zinc_metalloproteins/data`` directory (or on `GitHub <https://github.com/ccsb-scripps/AutoDock-Vina/tree/develop/example/docking_with_zinc_metalloproteins>`_). If you ever feel lost, you can always take a look at the solution here: ``AutoDock-Vina/example/docking_with_zinc_metalloproteins/solution``. All the Python scripts used here (except for ``prepare_receptor`` and ``mk_prepare_ligand.py``) are located in the ``AutoDock-Vina/example/autodock_scripts`` directory, alternatively you can also find them here on `GitHub <https://github.com/ccsb-scripps/AutoDock-Vina/tree/develop/example/autodock_scripts>`_.
+For this tutorial, all the basic material are provided and can be found in the ``AutoDock-Vina/example/docking_with_zinc_metalloproteins/data`` directory (or on `GitHub <https://github.com/ccsb-scripps/AutoDock-Vina/tree/develop/example/docking_with_zinc_metalloproteins>`_). If you ever feel lost, you can always take a look at the solution here: ``AutoDock-Vina/example/docking_with_zinc_metalloproteins/solution``. All the Python scripts used here (except for ``prepare_receptor`` and ``mk_prepare_ligand.py``) are located in the ``AutoDock-Vina/example/autodock_scripts`` directory, alternatively you can also find them here on `GitHub <https://github.com/ccsb-scripps/AutoDock-Vina/tree/develop/example/autodock_scripts>`_.
 
 1. Preparing the receptor
 -------------------------
 
-During this step we will create the PDBQT file of the receptor using the PDB file called ``proteinH.pdb``, containing all the hydrogen atoms, and add the tetrahedral zinc pseudo atoms (``TZ``) around the Zinc ion. TZ atoms represent the preferred position for tetrahedral coordination by the ligand. This file contains the receptor coordinates of chain A and B taken from the PDB entry `1s63 <https://www.rcsb.org/structure/1S63>`_.
+During this step we will create the PDBQT file of the receptor using the PDB file called ``proteinH.pdb``, containing all the hydrogen atoms, and add the tetrahedral zinc pseudo atoms (``TZ``) around the zinc ion. TZ atoms represent the preferred position for tetrahedral coordination by the ligand. This file contains the receptor coordinates of chain A and B taken from the PDB entry `1s63 <https://www.rcsb.org/structure/1S63>`_.
 
 To prepare the receptor, execute the following command lines:
 


### PR DESCRIPTION
Changes:
- Added a `Materials for this tutorial` subsection
- The `mapwater.py` and `dry.py` python scripts do not use the `pythonsh` from the ADFR suite.