### PR TITLE
fix batch output names

### DIFF
--- a/src/lib/utils.cpp
+++ b/src/lib/utils.cpp
@@ -86,7 +86,7 @@ std::string get_filename(const std::string& s) {
         return(s.substr(i + 1, s.length() - i));
     }
 
-    return("");
+    return(s);
 }
 
 std::string get_file_contents(const std::string& filename) {   


### PR DESCRIPTION
With `--batch a.pdbqt b.pdbqt --dir results` all output files were (over)written to "results/_out.pdbqt", because the function that splits the basename of the ligand (used to name each output file) was returning an empty string if the ligands were in the current working directory.