### PR TITLE
Check if ligand is in grid and autobox for score and local only

### DIFF
--- a/docs/source/docking_requirements.rst
+++ b/docs/source/docking_requirements.rst
@@ -40,33 +40,34 @@ The Python package ``meeko`` is a new type of package developped in the Forli la
     - Hydrated docking
     - Macrocycles
 
-This new tool can be easily installed with all its depencies using `pip` or `conda` package managers.
-
-**Meeko installation using Conda**:
-
-The `Conda package manager <https://docs.conda.io/en/latest/>`_ is included as part of the Anaconda Python distribution, which can be download from `https://docs.continuum.io/anaconda/install <https://docs.continuum.io/anaconda/install/>`_. This is a Python distribution specially designed for scientific applications, with many of the most popular scientific packages preinstalled. Alternatively, you can use `Miniconda <https://conda.pydata.org/miniconda.html>`_, which includes only Python itself, plus the Conda package manager.
-
-1. Begin by installing the most recent 64 bit, Python 3.x version of either Anaconda or Miniconda
-2. (Optional, but highly suggested) If you want, you can create a dedicated environment for ``meeko`` and ``AutoDock Vina`` packages (see :ref:`installation`):
-
-.. code-block:: bash
-
-    conda create -n vina python=3
-    conda activate vina
-    conda install -c conda-forge -c ccsb-scripps vina
-
-3. And type the following command
-
-.. code-block:: bash
-
-    conda install -c ccsb-scripps meeko
-
 **Meeko installation using pip**:
 
-.. code-block:: bash
+.. note::
 
-    pip install meeko
+    When using ``pip``, it's good pratice to use a virtual environment and also the easiest solution. An example with the `Conda package manager <https://docs.conda.io/en/latest/>`_ is available further down.
+
+.. warning::
+    
+    OpenBabel executable and library must be installed first, see `installation instruction <https://open-babel.readthedocs.io/en/latest/Installation/install.html#install-binaries>`_.
+
+.. code-block:: bash
+    
+    $ pip install -U numpy openbabel meeko
 
 If the installation was successful, you should now be able to access to the following command from your terminal by typing:
 
     - mk_prepare_ligand.py
+
+**Meeko installation in a Conda environment**:
+
+.. note::
+
+    See instructions in :ref:`installation` on how to setup and create an dedicated ``Conda`` environment.
+
+Type the following command to install ``NumPy``, ``OpenBabel`` and ``meeko``:
+
+.. code-block:: bash
+    
+    $ conda activate vina
+    $ conda install numpy openbabel
+    $ pip install meeko

--- a/docs/source/docking_requirements.rst
+++ b/docs/source/docking_requirements.rst
@@ -69,5 +69,5 @@ Type the following command to install ``NumPy``, ``OpenBabel`` and ``meeko``:
 .. code-block:: bash
     
     $ conda activate vina
-    $ conda install numpy openbabel
+    $ conda install -c conda-forge numpy openbabel
     $ pip install meeko

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -3,6 +3,10 @@
 Installation
 ============
 
+.. warning::
+
+    Currently, the python bindings and the binary installation are two separate processes. The installation of the python bindings does not include the Vina executable, and vice versa.
+
 Unix- and Linux-based OS
 ------------------------
 
@@ -32,28 +36,34 @@ If the executable is in your PATH, you can just type "vina --help" instead.
 Python bindings
 ---------------
 
-**AutoDock Vina installation using Conda**:
+**AutoDock Vina installation using pip**:
 
-The `Conda package manager <https://docs.conda.io/en/latest/>`_ is included as part of the Anaconda Python distribution, which can be download from `https://docs.continuum.io/anaconda/install <https://docs.continuum.io/anaconda/install/>`_. This is a Python distribution specially designed for scientific applications, with many of the most popular scientific packages preinstalled. Alternatively, you can use `Miniconda <https://conda.pydata.org/miniconda.html>`_, which includes only Python itself, plus the Conda package manager.
+.. note::
+
+    When using ``pip``, it's good pratice to use a virtual environment and also the easiest solution (see ``meeko`` in :ref:`docking_requirements`). An example with the `Conda package manager <https://docs.conda.io/en/latest/>`_ is available further down.
+
+.. code-block:: bash
+    
+    $ pip install -U numpy vina
+
+**AutoDock Vina installation in a Conda environment**:
+
+The Anaconda Python distribution, which can be download from `https://docs.continuum.io/anaconda/install <https://docs.continuum.io/anaconda/install/>`_. This is a Python distribution specially designed for scientific applications, with many of the most popular scientific packages preinstalled. Alternatively, you can use `Miniconda <https://conda.pydata.org/miniconda.html>`_, which includes only Python itself, plus the Conda package manager.
 
 1. Begin by installing the most recent 64 bit, Python 3.x version of either Anaconda or Miniconda
-2. (Optional, but highly suggested) If you want, you can create a dedicated environment for the ``AutoDock Vina`` package:
+2. Create a dedicated environment for ``AutoDock Vina``. This environment can be re-used for installing ``meeko`` (see :ref:`docking_requirements`):
 
 .. code-block:: bash
 
     $ conda create -n vina python=3
     $ conda activate vina
+    $ conda config --env --add channels conda-forge
 
-3. And type the following command
-
-.. code-block:: bash
-
-    $ conda install -c conda-forge -c ccsb-scripps vina
-
-**AutoDock Vina installation using pip**:
+3. And type the following command to install ``NumPy`` and ``AutoDock Vina``:
 
 .. code-block:: bash
 
+    $ conda install numpy
     $ pip install vina
 
 Building from Source
@@ -72,7 +82,7 @@ Building from Source
 
 - Step 3: **Build Vina**
 
-    Start by downloading the lastest version of AutoDock Vina from github:
+    Start by downloading the lastest version of ``AutoDock Vina`` from github:
 
     .. code-block:: bash
     
@@ -87,7 +97,14 @@ Building from Source
 
     To compile the Python bindings:
 
+    .. note::
+
+        The ``Conda`` package manager is used here to easily install the several dependencies needed to build the ``Autodock-Vina`` python bindings (see above how to create a dedicated environment).
+
     .. code-block:: bash
 
+        $ conda activate vina
         $ cd AutoDock-Vina/build/python
-        $ python setup.py clean --all build install
+        $ conda install numpy boost-cpp swig
+        $ rm -rf build dist *.egg-info (to clean previous installation)
+        $ python setup.py build install

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -105,6 +105,6 @@ Building from Source
 
         $ conda activate vina
         $ cd AutoDock-Vina/build/python
-        $ conda install numpy boost-cpp swig
+        $ conda install -c conda-forge numpy boost-cpp swig
         $ rm -rf build dist *.egg-info (to clean previous installation)
         $ python setup.py build install

--- a/src/lib/ad4cache.h
+++ b/src/lib/ad4cache.h
@@ -37,24 +37,28 @@
 #include "model.h"
 #include "file.h"
 #include "szv_grid.h"
+#include "common.h"
 
 
 struct ad4cache : public igrid {
-    ad4cache() {}
-	ad4cache(fl slope_);
+public:
+    ad4cache(fl slope=1e6): m_slope(slope), m_grids(AD_TYPE_SIZE + 2) {}
 	fl eval      (const model& m, fl v) const; // needs m.coords // clean up
 	fl eval_intra(      model& m, fl v) const; // needs m.coords, sets m.minus_forces // clean up
 	fl eval_deriv(      model& m, fl v) const; // needs m.coords, sets m.minus_forces // clean up
+    grid_dims gd() const { return m_gd; }
+    vec corner1() const { vec corner(m_gd[0].begin, m_gd[1].begin, m_gd[2].begin); return corner; }
+    vec corner2() const { vec corner(m_gd[0].end, m_gd[1].end, m_gd[2].end); return corner; }
     bool is_in_grid(const model &m, fl margin=0.0001) const;
-    bool is_atom_type_grid_initialized(sz t) const { return grids[t].initialized(); }
+    bool is_atom_type_grid_initialized(sz t) const { return m_grids[t].initialized(); }
     bool are_atom_types_grid_initialized(szv atom_types) const;
-    grid_dims read(const std::string& str);
+    void read(const std::string& str);
     void write(const std::string& out_prefix, const szv& atom_types, const std::string& gpf_filename="NULL",
                const std::string& fld_filename="NULL", const std::string& receptor_filename="NULL");
 private:
-	grid_dims gd;
-	fl slope; // does not get (de-)serialized
-	std::vector<grid> grids;
+	grid_dims m_gd;
+	fl m_slope; // does not get (de-)serialized
+	std::vector<grid> m_grids;
 };
 
 #endif

--- a/src/lib/cache.h
+++ b/src/lib/cache.h
@@ -43,22 +43,26 @@ struct precalculate;
 struct model;
 
 struct cache : public igrid {
-    cache() {}
-	cache(fl slope_);
+public:
+    cache(fl slope=1e6) : m_slope(slope), m_grids(XS_TYPE_SIZE) {}
+	cache(const grid_dims& gd, fl slope=1e6) : m_gd(gd), m_slope(slope), m_grids(XS_TYPE_SIZE) {}
 	fl eval      (const model& m, fl v) const; // needs m.coords // clean up
 	fl eval_intra(      model& m, fl v) const; // needs m.coords // clean up
 	fl eval_deriv(      model& m, fl v) const; // needs m.coords, sets m.minus_forces // clean up
+    grid_dims gd() const { return m_gd; }
+    vec corner1() const { vec corner(m_gd[0].begin, m_gd[1].begin, m_gd[2].begin); return corner; }
+    vec corner2() const { vec corner(m_gd[0].end, m_gd[1].end, m_gd[2].end); return corner; }
     bool is_in_grid(const model &m, fl margin=0.0001) const;
-    bool is_atom_type_grid_initialized(sz t) const { return grids[t].initialized(); }
+    bool is_atom_type_grid_initialized(sz t) const { return m_grids[t].initialized(); }
     bool are_atom_types_grid_initialized(szv atom_types) const;
-    grid_dims read(const std::string& str);
+    void read(const std::string& str);
     void write(const std::string& out_prefix, const szv& atom_types, const std::string& gpf_filename="NULL",
                const std::string& fld_filename="NULL", const std::string& receptor_filename="NULL");
-	void populate(const model& m, const precalculate& p, const grid_dims& gd, const szv& atom_types_needed);
+	void populate(const model& m, const precalculate& p, const szv& atom_types_needed);
 private:
-	grid_dims gd;
-	fl slope; // does not get (de-)serialized
-	std::vector<grid> grids;
+	grid_dims m_gd;
+	fl m_slope; // does not get (de-)serialized
+	std::vector<grid> m_grids;
 };
 
 #endif

--- a/src/lib/model.cpp
+++ b/src/lib/model.cpp
@@ -601,37 +601,12 @@ conf model::get_initial_conf() const { // torsions = 0, orientations = identity,
 	return tmp;
 }
 
-grid_dims model::movable_atoms_box(fl add_to_each_dimension, fl granularity) const {
-	vec corner1(0, 0, 0), corner2(0, 0, 0);
-	VINA_FOR(i, num_movable_atoms()) {
-		const vec& v = movable_coords(i);
-		VINA_FOR_IN(j, v) {
-			if(i == 0 || v[j] < corner1[j]) corner1[j] = v[j];
-			if(i == 0 || v[j] > corner2[j]) corner2[j] = v[j];
-		}
-	}
-	corner1 -= add_to_each_dimension / 2;
-	corner2 += add_to_each_dimension / 2;
-
-	grid_dims gd;
-	{ // always doing this now FIXME ?
-		vec center; center = 0.5 * (corner2 + corner1);
-		VINA_FOR_IN(i, gd) {
-			gd[i].n_voxels = sz(std::ceil((corner2[i] - corner1[i]) / granularity));
-			fl real_span = granularity * gd[i].n_voxels;
-			gd[i].begin = center[i] - real_span/2;
-			gd[i].end = gd[i].begin + real_span;
-		}
-	}
-	return gd;
-}
-
 vecv model::get_ligand_coords() const { // FIXME rm
 	VINA_CHECK(ligands.size() == 1);
 	vecv tmp;
 	const ligand &lig = ligands.front();
 	VINA_RANGE(i, lig.begin, lig.end)
-	tmp.push_back(coords[i]);
+		tmp.push_back(coords[i]);
 	return tmp;
 }
 
@@ -640,8 +615,7 @@ std::vector<double> model::get_ligand_coords() {
 	VINA_CHECK(ligands.size() == 1);
 	std::vector<double> tmp;
 	const ligand &lig = ligands.front();
-	VINA_RANGE(i, lig.begin, lig.end)
-	{
+	VINA_RANGE(i, lig.begin, lig.end) {
 		tmp.push_back(coords[i][0]);
 		tmp.push_back(coords[i][1]);
 		tmp.push_back(coords[i][2]);
@@ -651,16 +625,19 @@ std::vector<double> model::get_ligand_coords() {
 
 vecv model::get_heavy_atom_movable_coords() const { // FIXME mv
 	vecv tmp;
-	VINA_FOR(i, num_movable_atoms())
-	if (atoms[i].el != EL_TYPE_H)
-		tmp.push_back(coords[i]);
+
+	VINA_FOR(i, num_movable_atoms()) {
+		if (atoms[i].el != EL_TYPE_H)
+			tmp.push_back(coords[i]);
+	}
 	return tmp;
 }
 
 sz model::find_ligand(sz a) const {
-	VINA_FOR_IN(i, ligands)
+	VINA_FOR_IN(i, ligands) {
 		if(a >= ligands[i].begin && a < ligands[i].end)
 			return i;
+	}
 	return ligands.size();
 }
 
@@ -677,6 +654,22 @@ bool model::is_movable_atom(sz a) const {
 		return true;
 	else
 		return false;
+}
+
+std::vector<double> model::center() const {
+	std::vector<double> center(3, 0);
+
+	VINA_FOR(i, num_movable_atoms()) {
+		center[0] += coords[i][0];
+		center[1] += coords[i][1];
+		center[2] += coords[i][2];
+	}
+
+	center[0] /= num_movable_atoms();
+	center[1] /= num_movable_atoms();
+	center[2] /= num_movable_atoms();
+
+	return center;
 }
 
 void string_write_coord(sz i, fl x, std::string& str) {

--- a/src/lib/model.h
+++ b/src/lib/model.h
@@ -87,6 +87,7 @@ public:
 
 	bool is_atom_in_ligand(sz a) const;
 	bool is_movable_atom(sz a) const;
+	std::vector<double> center() const;
 	sz find_ligand(sz a) const;
 	sz num_atoms() const { return atoms.size(); }
 	sz num_movable_atoms() const { return m_num_movable_atoms; }
@@ -104,7 +105,6 @@ public:
 	vecv get_heavy_atom_movable_coords() const;
 	conf_size get_size() const;
 	conf get_initial_conf() const; // torsions = 0, orientations = identity, ligand positions = current
-	grid_dims movable_atoms_box(fl add_to_each_dimension, fl granularity = 0.375) const;
 
 	void write_flex  (                  const path& name, const std::string& remark) const { write_context(flex_context, name, remark); }
 	void write_ligand(sz ligand_number, const path& name, const std::string& remark) const { VINA_CHECK(ligand_number < ligands.size()); write_context(ligands[ligand_number].cont, name, remark); }

--- a/src/lib/vina.cpp
+++ b/src/lib/vina.cpp
@@ -298,11 +298,11 @@ std::vector<double> Vina::grid_dimensions_from_ligand(double buffer_size) {
 		const vec& atom_coords = m_model.get_coords(i);
 
 		VINA_FOR_IN(j, atom_coords) {
-			double distance = std::sqrt(std::pow((box_center[j] - atom_coords[j]), 2));
+			double distance = std::fabs(box_center[j] - atom_coords[j]);
 
 			if (max_distance[j] < distance)
 				max_distance[j] = distance;
-		}	
+		}
 	}
 
 	// Get the final dimensions of the box
@@ -327,10 +327,10 @@ void Vina::compute_vina_maps(double center_x, double center_y, double center_z, 
 		std::cerr << "ERROR: Cannot compute Vina or Vinardo affinity maps. The (rigid) receptor was not initialized.\n";
 		exit(EXIT_FAILURE);
 	} else if (size_x <= 0 || size_y <= 0 || size_z <= 0) {
-		std::cerr << "ERROR: Grid box dimensions must be superior than 0 Angstrom.\n";
+		std::cerr << "ERROR: Grid box dimensions must be greater than 0 Angstrom.\n";
 		exit(EXIT_FAILURE);
 	} else if (size_x * size_y * size_z > 27e3) {
-		std::cerr << "WARNING: The search space volume > 27000 Angstrom^3 (See FAQ)\n";
+		std::cerr << "WARNING: Search space volume is greater than 27000 Angstrom^3 (See FAQ)\n";
 	}
 
 	grid_dims gd;

--- a/src/lib/vina.h
+++ b/src/lib/vina.h
@@ -107,18 +107,21 @@ public:
 	void set_ligand_from_file(const std::vector<std::string>& ligand_name);
 	//void set_ligand(OpenBabel::OBMol* mol);
 	//void set_ligand(std::vector<OpenBabel::OBMol*> mol);
-	void set_vina_weights(double weight_gauss1=-0.035579,  double weight_gauss2=-0.005156,
-						  double weight_repulsion=0.840245, double weight_hydrophobic=-0.035069,
-						  double weight_hydrogen=-0.587439, double weight_glue=50,
-						  double weight_rot=0.05846);
+	void set_vina_weights(double weight_gauss1=-0.035579, double weight_gauss2=-0.005156,
+						       double weight_repulsion=0.840245, double weight_hydrophobic=-0.035069,
+						       double weight_hydrogen=-0.587439, double weight_glue=50,
+						       double weight_rot=0.05846);
 	void set_vinardo_weights(double weight_gauss1=-0.045,
-							 double weight_repulsion=0.8, double weight_hydrophobic=-0.035,
-							 double weight_hydrogen=-0.600, double weight_glue=50,
-							 double weight_rot=0.05846);
+							       double weight_repulsion=0.8, double weight_hydrophobic=-0.035,
+							       double weight_hydrogen=-0.600, double weight_glue=50,
+							       double weight_rot=0.05846);
 	void set_ad4_weights(double weight_ad4_vdw=0.1662, double weight_ad4_hb=0.1209,
-						 double weight_ad4_elec=0.1406, double weight_ad4_dsolv=0.1322,
-						 double weight_glue=50, double weight_ad4_rot=0.2983);
-	void compute_vina_maps(double center_x, double center_y, double center_z, double size_x, double size_y, double size_z, double granularity=0.5, bool force_even_voxels=false);
+						      double weight_ad4_elec=0.1406, double weight_ad4_dsolv=0.1322,
+						      double weight_glue=50, double weight_ad4_rot=0.2983);
+	std::vector<double> grid_dimensions_from_ligand(double buffer_size=4);
+	void compute_vina_maps(double center_x, double center_y, double center_z,
+								  double size_x, double size_y, double size_z,
+								  double granularity=0.5, bool force_even_voxels=false);
 	void load_maps(std::string maps);
 	void randomize(const int max_steps=10000);
 	std::vector<double> score();
@@ -130,7 +133,7 @@ public:
 	void write_pose(const std::string &output_name, const std::string &remark = std::string());
 	void write_poses(const std::string &output_name, int how_many=9, double energy_range=3.0);
 	void write_maps(const std::string& map_prefix="receptor", const std::string& gpf_filename="NULL",
-					const std::string& fld_filename="NULL", const std::string& receptor_filename="NULL");
+					    const std::string& fld_filename="NULL", const std::string& receptor_filename="NULL");
 	void show_score(const std::vector<double> energies);
 
 private:
@@ -149,11 +152,8 @@ private:
 	precalculate m_precalculated_sf;
 	// maps
 	cache m_grid;
-	non_cache m_non_cache;
 	ad4cache m_ad4grid;
-	grid_dims m_gd;
-	vec m_corner1;
-	vec m_corner2;
+	non_cache m_non_cache;
 	bool m_map_initialized;
 	// global search
 	int m_cpu;
@@ -166,7 +166,6 @@ private:
 	output_container remove_redundant(const output_container& in, fl min_rmsd);
 
 	void set_forcefield();
-	void set_vina_box(double center_x, double center_y, double center_z, double size_x, double size_y, double size_z, double granularity=0.375, bool force_even_voxels=false);
 	std::vector<double> score(double intramolecular_energy);
 	std::vector<double> optimize(output_type& out, const int max_steps=0);
 	int generate_seed(const int seed=0);

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -188,7 +188,7 @@ Thank you!\n";
 			("size_x", value<double>(&size_x), "size in the X dimension (Angstrom)")
 			("size_y", value<double>(&size_y), "size in the Y dimension (Angstrom)")
 			("size_z", value<double>(&size_z), "size in the Z dimension (Angstrom)")
-			("autobox", bool_switch(&autobox), "box dimensions automatically defined based on the input ligand(s) (score and local only, expect in batch mode.")
+			("autobox", bool_switch(&autobox), "set maps dimensions based on input ligand(s) (for --score_only and --local_only)")
 		;
 		//options_description outputs("Output prefixes (optional - by default, input names are stripped of .pdbqt\nare used as prefixes. _001.pdbqt, _002.pdbqt, etc. are appended to the prefixes to produce the output names");
 		options_description outputs("Output (optional)");

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -131,6 +131,7 @@ Thank you!\n";
 		double min_rmsd = 1.0;
 		double energy_range = 3.0;
 		double grid_spacing = 0.375;
+		double buffer_size = 4;
 
 		// autodock4.2 weights
 		double weight_ad4_vdw   = 0.1662;
@@ -164,6 +165,7 @@ Thank you!\n";
 		bool help = false;
 		bool help_advanced = false;
 		bool version = false; // FIXME
+		bool autobox = false;
 		variables_map vm;
 
 		positional_options_description positional; // remains empty
@@ -186,6 +188,7 @@ Thank you!\n";
 			("size_x", value<double>(&size_x), "size in the X dimension (Angstrom)")
 			("size_y", value<double>(&size_y), "size in the Y dimension (Angstrom)")
 			("size_z", value<double>(&size_z), "size in the Z dimension (Angstrom)")
+			("autobox", bool_switch(&autobox), "box dimensions automatically defined based on the input ligand(s) (score and local only, expect in batch mode.")
 		;
 		//options_description outputs("Output prefixes (optional - by default, input names are stripped of .pdbqt\nare used as prefixes. _001.pdbqt, _002.pdbqt, etc. are appended to the prefixes to produce the output names");
 		options_description outputs("Output (optional)");
@@ -364,10 +367,14 @@ Thank you!\n";
 			} else if (batch_ligand_names.size() > 1) {
 				std::cout << "Ligands (batch mode): " << batch_ligand_names.size() << " molecules\n";
 			}
-			if (!vm.count("maps")) {
-				std::cout << "Center: X " << center_x << " Y " << center_y << " Z " << center_z << "\n";
-				std::cout << "Size: X " << size_x << " Y " << size_y << " Z " << size_z << "\n";
-				std::cout << "Grid space: " << grid_spacing << "\n";
+			if (!vm.count("maps") & !autobox) {
+				std::cout << "Grid center: X " << center_x << " Y " << center_y << " Z " << center_z << "\n";
+				std::cout << "Grid size  : X " << size_x << " Y " << size_y << " Z " << size_z << "\n";
+				std::cout << "Grid space : " << grid_spacing << "\n";
+			} else if (autobox) {
+				std::cout << "Grid center: ligand center (autobox)\n";
+				std::cout << "Grid size  : ligand size + " << buffer_size << " A in each dimension (autobox)\n";
+				std::cout << "Grid space : " << grid_spacing << "\n";
 			}
 			std::cout << "Exhaustiveness: " << exhaustiveness << "\n";
 			std::cout << "CPU: " << cpu << "\n";
@@ -410,7 +417,13 @@ Thank you!\n";
 					v.load_maps(maps);
 				} else {
 					// Will compute maps only for Vina atom types in the ligand(s)
-					v.compute_vina_maps(center_x, center_y, center_z, size_x, size_y, size_z, grid_spacing, force_even_voxels);
+					// In the case users ask for score and local only with the autobox arg, we compute the optimal box size for it/them.
+					if ((score_only || local_only) & autobox) {
+						std::vector<double> dim = v.grid_dimensions_from_ligand(buffer_size);
+						v.compute_vina_maps(dim[0], dim[1], dim[2], dim[3], dim[4], dim[5], grid_spacing, force_even_voxels);
+					} else {
+						v.compute_vina_maps(center_x, center_y, center_z, size_x, size_y, size_z, grid_spacing, force_even_voxels);
+					}
 
 					if (vm.count("write_maps"))
 						v.write_maps(out_maps);


### PR DESCRIPTION
Improvements related to issue #31:
- Check if the ligand(s) is(are) in the grid when `--score_only`and `local_only` requested.
- Use argument `--autobox` in combination `--score_only` and `--local_only` for automatically define the grid box around the ligand(s). This does not work with the `--batch` mode (cannot know beforehand the dimensions of the box without reading all the ligand first).

Miscellaneous: 
- Moved `gd`, `corner1` and `corner2` in `cache` and `ad4cache` objects, instead of having them floating around...
- Dropped Conda for installing meeko and vina, but still keep instructions on how to setup a conda environment (easier to install OpenBabel using conda). 