### PR TITLE
Unbound energy

### DIFF
--- a/build/python/vina/vina.py
+++ b/build/python/vina/vina.py
@@ -399,8 +399,11 @@ class Vina:
         """Randomize the input ligand conformation."""
         self._vina.randomize()
     
-    def score(self):
+    def score(self, unbound_energy=None):
         """Score current pose.
+
+        Args:
+            unbound_energy (float): Optionally pass the unbound systems energy of the ligand.
 
         Returns:
             nadarray: Array of energies from current pose.
@@ -414,7 +417,10 @@ class Vina:
         """
         # It does not make sense to report energies with a precision higher than 3
         # since the coordinates precision is 3.
-        energies = np.around(self._vina.score(), decimals=3)
+        if unbound_energy is None:
+            energies = np.around(self._vina.score(), decimals=3)
+        else:
+            energies = np.around(self._vina.score(unbound_energy), decimals=3)
         return energies
 
     def optimize(self, max_steps=0):

--- a/src/lib/vina.cpp
+++ b/src/lib/vina.cpp
@@ -683,7 +683,7 @@ void Vina::randomize(const int max_steps) {
 }
 
 void Vina::show_score(const std::vector<double> energies) {
-	std::cout << "Estimated Free Energy of Binding   : " << std::fixed << std::setprecision(3) << energies[0] << " (kcal/mol) [=(1)+(2)+(3)+(4)]\n";
+	std::cout << "Estimated Free Energy of Binding   : " << std::fixed << std::setprecision(3) << energies[0] << " (kcal/mol) [=(1)+(2)+(3)-(4)]\n";
 	std::cout << "(1) Final Intermolecular Energy    : " << std::fixed << std::setprecision(3) << energies[1] + energies[2] << " (kcal/mol)\n";
 	std::cout << "    Ligand - Receptor              : " << std::fixed << std::setprecision(3) << energies[1] << " (kcal/mol)\n";
 	std::cout << "    Ligand - Flex side chains      : " << std::fixed << std::setprecision(3) << energies[2] << " (kcal/mol)\n";
@@ -762,7 +762,7 @@ std::vector<double> Vina::score(double intramolecular_energy) {
 	if (m_sf_choice == SF_VINA  || m_sf_choice == SF_VINARDO) {
 		energies.push_back(intramolecular_energy);
 	} else {
-		energies.push_back(-intra);
+		energies.push_back(intra);
 	}
 
 	return energies;

--- a/src/lib/vina.cpp
+++ b/src/lib/vina.cpp
@@ -964,6 +964,7 @@ void Vina::global_search(const int exhaustiveness, const int n_poses, const doub
 				}
 			}
 
+			m_model.set(poses[0].c);
 			if (m_no_refine || !m_receptor_initialized)
 				intramolecular_energy = m_model.eval_intramolecular(m_precalculated_byatom, m_grid, authentic_v);
 			else

--- a/src/lib/vina.h
+++ b/src/lib/vina.h
@@ -126,6 +126,7 @@ public:
 	void load_maps(std::string maps);
 	void randomize(const int max_steps=10000);
 	std::vector<double> score();
+	std::vector<double> score(double intramolecular_energy);
 	std::vector<double> optimize(const int max_steps=0);
 	void global_search(const int exhaustiveness=8, const int n_poses=20, const double min_rmsd=1.0, const int max_evals=0);
 	std::string get_poses(int how_many=9, double energy_range=3.0);
@@ -168,7 +169,6 @@ private:
 	output_container remove_redundant(const output_container& in, fl min_rmsd);
 
 	void set_forcefield();
-	std::vector<double> score(double intramolecular_energy);
 	std::vector<double> optimize(output_type& out, const int max_steps=0);
 	int generate_seed(const int seed=0);
 };

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -132,6 +132,7 @@ Thank you!\n";
 		double energy_range = 3.0;
 		double grid_spacing = 0.375;
 		double buffer_size = 4;
+                double unbound_energy = NAN;
 
 		// autodock4.2 weights
 		double weight_ad4_vdw   = 0.1662;
@@ -201,6 +202,7 @@ Thank you!\n";
 		advanced.add_options()
 			("score_only",     bool_switch(&score_only),     "score only - search space can be omitted")
 			("local_only",     bool_switch(&local_only),     "do local search only")
+			("unbound_energy", value<double>(&unbound_energy)->default_value(unbound_energy), "Explicitly set the Unbound System's Energy for --score_only jobs")
 			("no_refine", bool_switch(&no_refine),  "when --receptor is provided, do not use explicit receptor atoms (instead of precalculated grids) for: (1) local optimization and scoring after docking, (2) --local_only jobs, and (3) --score_only jobs")
 			("force_even_voxels", bool_switch(&force_even_voxels),  "calculated grid maps will have an even number of voxels (intervals) in each dimension (odd number of grid points)")
 			("randomize_only", bool_switch(&randomize_only), "randomize input, attempting to avoid clashes")
@@ -435,7 +437,11 @@ Thank you!\n";
 				v.write_pose(out_name);
 			} else if (score_only) {
 				std::vector<double> energies;
-				energies = v.score();
+                                if (std::isnan(unbound_energy)) {
+				        energies = v.score();
+                                } else {
+				        energies = v.score(unbound_energy);
+                                }
 				v.show_score(energies);
 			} else if (local_only) {
 				std::vector<double> energies;
@@ -468,7 +474,11 @@ Thank you!\n";
 					v.randomize();
 					v.write_pose(out_name);
 				} else if (score_only) {
-					v.score();
+                                        if (std::isnan(unbound_energy)) {
+                                                v.score();
+                                        } else {
+				                v.score(unbound_energy);
+                                        }
 				} else if (local_only) {
 					v.optimize();
 					v.write_pose(out_name);

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -132,7 +132,7 @@ Thank you!\n";
 		double energy_range = 3.0;
 		double grid_spacing = 0.375;
 		double buffer_size = 4;
-                double unbound_energy = NAN;
+		double unbound_energy = NAN;
 
 		// autodock4.2 weights
 		double weight_ad4_vdw   = 0.1662;
@@ -437,11 +437,11 @@ Thank you!\n";
 				v.write_pose(out_name);
 			} else if (score_only) {
 				std::vector<double> energies;
-                                if (std::isnan(unbound_energy)) {
-				        energies = v.score();
-                                } else {
-				        energies = v.score(unbound_energy);
-                                }
+				if (std::isnan(unbound_energy)) {
+					energies = v.score();
+				} else {
+					energies = v.score(unbound_energy);
+				}
 				v.show_score(energies);
 			} else if (local_only) {
 				std::vector<double> energies;
@@ -474,11 +474,11 @@ Thank you!\n";
 					v.randomize();
 					v.write_pose(out_name);
 				} else if (score_only) {
-                                        if (std::isnan(unbound_energy)) {
-                                                v.score();
-                                        } else {
-				                v.score(unbound_energy);
-                                        }
+					if (std::isnan(unbound_energy)) {
+						v.score();
+					} else {
+						v.score(unbound_energy);
+					}
 				} else if (local_only) {
 					v.optimize();
 					v.write_pose(out_name);


### PR DESCRIPTION
- When using VINA or VINARDO as scoring and using refinement of the structures after docking, the `Unbound System's energy` was obtained from the worst pose instead of the best pose.
I couldn't reproduce it locally, but I expect it to close issue #68.
- Fix typo as pointed out in issue #68 and fixed sign-inconsistency for unbound system's energy between different scorings.
- Expose `score(unbound_energy)` in python bindings and CLI (through `--unbound_energy` when using `--score_only`). This is handy when you want to rescore a pose with a 'custom' unbound energy (i.e. if you are not using the intramolecular energy of that particular pose as unbound energy).