### PR TITLE
Add exception PDBQT_PARSE_ERROR for python

### DIFF
--- a/build/python/vina/autodock_vina.i
+++ b/build/python/vina/autodock_vina.i
@@ -64,6 +64,7 @@
 #include "tree.h"
 #include "triangular_matrix_index.h"
 #include "utils.h"
+SWIGRUNTIME PyObject* pPDBQT_PARSE_ERROR;
 %}
 
 // Set and reset dlopenflags so that plugin loading works fine for "import _openbabel"
@@ -75,17 +76,41 @@ if sys.platform.find("linux") != -1:
     sys.setdlopenflags(dlflags | ctypes.RTLD_GLOBAL)
 %}
 %pythoncode %{
+PDBQT_PARSE_ERROR = _vina_wrapper.PDBQT_PARSE_ERROR
 if sys.platform.find("linux") != -1:
     sys.setdlopenflags(dlflags)
 %}
-
+%init %{
+    pPDBQT_PARSE_ERROR = PyErr_NewException("_vina_wrapper.PDBQT_PARSE_ERROR", NULL, NULL);
+    Py_INCREF(pPDBQT_PARSE_ERROR);
+    PyModule_AddObject(m, "PDBQT_PARSE_ERROR", pPDBQT_PARSE_ERROR);
+%}
 // Add standard C++ library
 %include "std_array.i"
 %include "std_list.i"
 %include "std_map.i"
 %include "std_vector.i"
 %include "std_string.i"
-
+%include "stl.i"
+%include "exception.i"
+%exception set_ligand_from_string{
+    try {
+        $action
+    }
+    catch (const pdbqt_parse_error & e) {
+        PyErr_SetString(pPDBQT_PARSE_ERROR, e.what());
+        SWIG_fail;
+    }
+}
+%exception set_ligand_from_file{
+    try {
+        $action
+    }
+    catch (const pdbqt_parse_error & e) {
+        PyErr_SetString(pPDBQT_PARSE_ERROR, e.what());
+        SWIG_fail;
+    }
+}
 // Help SWIG to understand some special types, like list of strings
 namespace std {
     %template(IntVector) vector<int>;

--- a/src/lib/parse_pdbqt.cpp
+++ b/src/lib/parse_pdbqt.cpp
@@ -625,13 +625,13 @@ model parse_ligand_pdbqt_from_file(const std::string& name, atom_type::t atype) 
     non_rigid_parsed nrp;
     context c;
 
-    try {
+    // try {
         parse_pdbqt_ligand(make_path(name), nrp, c);
-    }
-    catch(pdbqt_parse_error& e) {
-        std::cerr << e.what();
-        exit(EXIT_FAILURE);
-    }
+    // }
+    // catch(pdbqt_parse_error& e) {
+    //     std::cerr << e.what();
+    //     exit(EXIT_FAILURE);
+    // }
 
     pdbqt_initializer tmp(atype);
     tmp.initialize_from_nrp(nrp, c, true);
@@ -643,14 +643,14 @@ model parse_ligand_pdbqt_from_string(const std::string& string_name, atom_type::
     non_rigid_parsed nrp;
     context c;
 
-    try {
+    // try {
         std::stringstream molstream(string_name);
         parse_pdbqt_ligand(molstream, nrp, c);
-    }
-    catch(pdbqt_parse_error& e) {
-        std::cerr << e.what() << '\n';
-        exit(EXIT_FAILURE);
-    }
+    // }
+    // catch(pdbqt_parse_error& e) {
+    //     std::cerr << e.what() << '\n';
+    //     exit(EXIT_FAILURE);
+    // }
 
     pdbqt_initializer tmp(atype);
     tmp.initialize_from_nrp(nrp, c, true);


### PR DESCRIPTION
The program exits when I load a ligand which has an invalid atom type. This can be a disaster when performing virtual screening with python, because the try/except block will not work and the python process terminates. So I commented the try/catch block in C++ code and added a new exception `PDBQT_PARSE_ERROR` for python, which can be imported using `from vina.vina_wrapper import PDBQT_PARSE_ERROR`, so that the exception can be captured by python and the user could deal with the failed molecule later. This change basically won't affect the behavior of the binary of vina, since the uncaught exception will cause the process be killed by OS.