### PR TITLE
Update docking_requirements.rst

### DIFF
--- a/docs/source/docking_requirements.rst
+++ b/docs/source/docking_requirements.rst
@@ -69,5 +69,6 @@ Type the following command to install ``NumPy``, ``OpenBabel`` and ``meeko``:
 .. code-block:: bash
     
     $ conda activate vina
-    $ conda install -c conda-forge numpy openbabel
+    $ conda install python=3.9.7
+    $ conda install -c conda-forge numpy openbabel scipy rdkit
     $ pip install meeko


### PR DESCRIPTION
meeko apparently requires as well `scipy` and` rdkit`, and `rdkit` requires (as of this writting on 2022-03-09) `python >=3.9,<3.10.0a0` while `vina` installation installed 3.10...

It would be good if somebody better qualified for this than I am could review and synchronize these dependencies in the whole `autodock-vina` repo...