### PR TITLE
Added ability to only link static Boost libraries.

### DIFF
--- a/.github/workflows/compile-binaries.yaml
+++ b/.github/workflows/compile-binaries.yaml
@@ -50,6 +50,7 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: |
           $Url = "https://sourceforge.net/projects/boost/files/boost-binaries/1.77.0/boost_1_77_0-msvc-14.2-64.exe"
+          [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
           (New-Object System.Net.WebClient).DownloadFile($Url, "$env:TEMP\boost.exe")
           Start-Process -Wait -FilePath "$env:TEMP\boost.exe" "/SILENT","/SP-","/SUPPRESSMSGBOXES"
           cd .\build\windows

--- a/build/linux/debug/Makefile
+++ b/build/linux/debug/Makefile
@@ -2,7 +2,7 @@ BASE=/usr
 BOOST_VERSION=
 BOOST_INCLUDE = $(BASE)/include
 C_PLATFORM=-static -pthread
-GPP=/usr/bin/g++
+GPP=g++
 C_OPTIONS= -g -std=gnu++11
 BOOST_LIB_VERSION=
 

--- a/build/linux/release/Makefile
+++ b/build/linux/release/Makefile
@@ -5,5 +5,6 @@ C_PLATFORM=-static -pthread
 GPP=/usr/bin/g++
 C_OPTIONS= -O3 -DNDEBUG -std=c++11
 BOOST_LIB_VERSION=
+BOOST_STATIC=y
 
 include ../../makefile_common

--- a/build/linux/release/Makefile
+++ b/build/linux/release/Makefile
@@ -2,9 +2,8 @@ BASE=/usr/local
 BOOST_VERSION=
 BOOST_INCLUDE = $(BASE)/include
 C_PLATFORM=-static -pthread
-GPP=/usr/bin/g++
+GPP=g++
 C_OPTIONS= -O3 -DNDEBUG -std=c++11
 BOOST_LIB_VERSION=
-BOOST_STATIC=y
 
 include ../../makefile_common

--- a/build/mac/release/Makefile
+++ b/build/mac/release/Makefile
@@ -3,7 +3,8 @@ BOOST_VERSION=
 BOOST_INCLUDE = $(BASE)/include
 C_PLATFORM=-pthread
 GPP=/usr/bin/clang++
-C_OPTIONS= -O3 -DNDEBUG -std=c++11
+C_OPTIONS= -O3 -DNDEBUG -std=c++11 -fvisibility=hidden
 BOOST_LIB_VERSION=
+BOOST_STATIC=y
 
 include ../../makefile_common

--- a/build/makefile_common
+++ b/build/makefile_common
@@ -21,11 +21,19 @@ LDFLAGS = -L$(BASE)/lib -L.
 # install libboost_thread-mt, but not
 # libboost_thread (e.g. macOS)
 $(shell echo "int main(){ return 0; }" > linktest.cpp)
+ifeq ($(BOOST_STATIC), y)
+$(shell $(CC) $(LDFLAGS) ${BASE}/lib/libboost_thread-mt${BOOST_LIB_VERSION}.a linktest.cpp -o linktest >/dev/null 2>&1)
+else
 $(shell $(CC) $(LDFLAGS) -l boost_thread-mt${BOOST_LIB_VERSION} linktest.cpp -o linktest >/dev/null 2>&1)
+endif
 threadmt:=$(shell if [ -f ./linktest ]; then echo "-mt"; rm ./linktest; fi;)
 $(shell rm ./linktest.cpp)
 
+ifeq ($(BOOST_STATIC), y)
+LIBS = ${BASE}/lib/libboost_system${BOOST_LIB_VERSION}.a ${BASE}/lib/libboost_thread${threadmt}${BOOST_LIB_VERSION}.a ${BASE}/lib/libboost_serialization${BOOST_LIB_VERSION}.a ${BASE}/lib/libboost_filesystem${BOOST_LIB_VERSION}.a ${BASE}/lib/libboost_program_options${BOOST_LIB_VERSION}.a
+else
 LIBS = -l boost_system${BOOST_LIB_VERSION} -l boost_thread${threadmt}${BOOST_LIB_VERSION} -l boost_serialization${BOOST_LIB_VERSION} -l boost_filesystem${BOOST_LIB_VERSION} -l boost_program_options${BOOST_LIB_VERSION}#-l pthread
+endif
 
 .SUFFIXES: .cpp .o
 


### PR DESCRIPTION
This PR allows static linking of only the Boost libraries. To this end, the option `BOOST_STATIC=y` has been added to the release Makefile of the macOS build.

As Linux still uses `-static` for compilation this is a bit superfluous but it should work if a static version of Boost has been installed.

On macOS is where this option is most useful as it allows us to compile binaries for stock systems only missing Boost.