### PR TITLE
fix: fixed  DeprecationWarning from pytest about `np.int`.

### DIFF
--- a/build/python/vina/vina.py
+++ b/build/python/vina/vina.py
@@ -257,7 +257,7 @@ class Vina:
         self._center = center
         self._box_size = box_size
         self._spacing = spacing
-        self._voxels = np.ceil(np.array(box_size) / self._spacing).astype(np.int)
+        self._voxels = np.ceil(np.array(box_size) / self._spacing).astype(np.int32)
 
         # Necessary step to know if we can write maps or not later
         if force_even_voxels:


### PR DESCRIPTION
# Fixed DeprecationWarning from pytest about `np.int`.

-  DeprecationWarning: `np.int` is a deprecated alias for the builtin `int`. To silence this warning, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
-  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations `self._voxels = np.ceil(np.array(box_size) / self._spacing).astype(np.int)`

Changed `np.int` to `np.int32` in line 260 of `vina.py`.