### PR TITLE
Update model conf before calculating its clash_penalty.

### DIFF
--- a/build/python/vina/vina.py
+++ b/build/python/vina/vina.py
@@ -395,9 +395,14 @@ class Vina:
 
         return np.around(self._vina.get_poses_energies(n_poses, energy_range), decimals=3)
 
-    def randomize(self):
-        """Randomize the input ligand conformation."""
-        self._vina.randomize()
+    def randomize(self, max_steps=10000):
+        """Randomize the input ligand conformation.
+
+        Args:
+            max_steps (int): Number of poses to generate for selection of the best one.
+
+        """
+        self._vina.randomize(max_steps)
     
     def score(self, unbound_energy=None):
         """Score current pose.

--- a/src/lib/vina.cpp
+++ b/src/lib/vina.cpp
@@ -666,6 +666,7 @@ void Vina::randomize(const int max_steps) {
 	VINA_FOR(i, max_steps) {
 		c = init_conf;
 		c.randomize(m_grid.corner1(), m_grid.corner2(), generator);
+		m_model.set(c);
 		penalty = m_model.clash_penalty();
 
 		if (i == 0 || penalty < best_clash_penalty) {


### PR DESCRIPTION
Without this change, the pose to write is always the first randomized one and argument `max_steps` is meanless but wasting cpu time.