### PR TITLE
Correct ligand-receptor energy when no_refine is enabled.

### DIFF
--- a/src/lib/cache.cpp
+++ b/src/lib/cache.cpp
@@ -58,7 +58,6 @@ fl cache::eval(const model& m, fl v) const { // needs m.coords
 	sz nat = num_atom_types(atom_type::XS);
 
 	VINA_FOR(i, m.num_movable_atoms()) {
-		if(!m.is_atom_in_ligand(i)) continue; // we only want ligand - grid interaction
 		const atom& a = m.atoms[i];
 		sz t = a.get(atom_type::XS);
 


### PR DESCRIPTION
According to [vina.cpp#L719-L722](https://github.com/ccsb-scripps/AutoDock-Vina/blob/develop/src/lib/vina.cpp#L719-L722), function `igrid.eval()` should return energy between receptor and ligand when `vina`/`vinardo` score function is selected.

```c++
// Inter
if (m_no_refine || !m_receptor_initialized)
    all_grids = m_grid.eval(m_model, authentic_v[1]); // [1] ligand & flex -- grid
else
    all_grids = m_non_cache.eval(m_model, authentic_v[1]); // [1] ligand & flex -- grid
lig_grids = all_grids - flex_grids;
```

In default, `m_no_refine` is false and the behavior of function `non_cache.eval()` is correct. However, this is not true in function `cache.eval()`.

**Since ligand-receptor energy is calculated from `all_grids` minus `flex_grids`, this fix is necessary for a correct energy report when `no_refine` option is enabled in Vina.**

Since both `non_cache.eval()`  and `cache.eval()` are called only when scoring a model, search & optimization procedures won't be affected.

We can quickly verify the behavior change in Vina's `score_only` mode:
```bash
cd example/flexible_docking/solution
vina \
  --receptor 1fpu_receptor_rigid.pdbqt \
  --flex 1fpu_receptor_flex.pdbqt \
  --ligand ../data/1iep_ligand.pdbqt \
  --config 1fpu_receptor_rigid_vina_box.txt \
  --score_only \
  --seed 137 \
  --no_refine \
  --verbosity 2
```

Inserting extra log lines in `vina.cpp`, value delta of `all_grids` between unfixed and fixed equals exactly the value of `flex_grids`.
- Vina without this fix
```
[no_refine] all_grids=-4.38079
[no_refine] flex_grids=1.32849
```
- Vina with this fix
```
[no_refine] all_grids=-3.0523
[no_refine] flex_grids=1.32849
```