### PR TITLE
compatibility boost >= 1.83

### DIFF
--- a/src/lib/parallel_progress.h
+++ b/src/lib/parallel_progress.h
@@ -23,7 +23,14 @@
 #ifndef VINA_PARALLEL_PROGRESS_H
 #define VINA_PARALLEL_PROGRESS_H
 
+#include <boost/version.hpp>
+#if BOOST_VERSION < 107200
 #include <boost/progress.hpp>
+typedef boost::progress_display boost_progress;
+#else
+#include <boost/timer/progress_display.hpp>
+typedef boost::timer::progress_display boost_progress;
+#endif
 #include <boost/thread/mutex.hpp>
 
 #include <functional>
@@ -34,7 +41,7 @@ struct parallel_progress : public incrementable {
 	parallel_progress(std::function<void(double)>* c = NULL) : p(NULL), callback(c) {}
 	void init(unsigned long n) {
         count = n;
-        p = new boost::progress_display(count);
+        p = new boost_progress(count);
     }
 	void operator++() {
 		if(p) {
@@ -47,7 +54,7 @@ struct parallel_progress : public incrementable {
 	virtual ~parallel_progress() { delete p; }
 private:
 	boost::mutex self;
-	boost::progress_display* p;
+	boost_progress* p;
     std::function<void(double)>* callback;
     unsigned long count;
 };


### PR DESCRIPTION
In boost 1.83 boost/progress.hpp is deprecated.
I propose use this typedefs to use the correct class depending the boost version.