### PR TITLE
Fix leak in Vina::m_scoring_function reported by valgrind

### DIFF
--- a/src/lib/scoring_function.h
+++ b/src/lib/scoring_function.h
@@ -38,7 +38,10 @@ enum scoring_function_choice {SF_VINA, SF_AD42, SF_VINARDO};
 
 class ScoringFunction {
 public:
-    ScoringFunction() { }
+    ScoringFunction() {
+        m_num_potentials = 0;
+        m_num_conf_independents = 0;
+    }
     ScoringFunction(const scoring_function_choice sf_choice, const flv& weights){
         switch (sf_choice)
         {
@@ -94,7 +97,25 @@ public:
         m_num_conf_independents = m_conf_independents.size();
         m_weights = weights;
     };
-    ~ScoringFunction() { }
+    void Destroy()
+    {
+        for (auto p : m_potentials)
+        {
+            delete p;
+        }
+        m_potentials.clear();
+        m_num_potentials = 0;
+        for (auto p : m_conf_independents)
+        {
+            delete p;
+        }
+        m_conf_independents.clear();
+        m_num_conf_independents = 0;
+    }
+    ~ScoringFunction() {
+        Destroy();
+    }
+
     fl eval(atom& a, atom& b, fl r) const{ // intentionally not checking for cutoff
         fl acc = 0;
         VINA_FOR (i, m_num_potentials)

--- a/src/lib/vina.h
+++ b/src/lib/vina.h
@@ -53,6 +53,7 @@
 #include "utils.h"
 #include "scoring_function.h"
 #include "precalculate.h"
+#include <memory>
 
 
 class vina_runtime_error : public std::exception {
@@ -162,7 +163,7 @@ private:
 	// scoring function
 	scoring_function_choice m_sf_choice;
 	flv m_weights;
-	ScoringFunction m_scoring_function;
+	std::shared_ptr<ScoringFunction> m_scoring_function;
 	precalculate_byatom m_precalculated_byatom;
 	precalculate m_precalculated_sf;
 	// maps


### PR DESCRIPTION
Fixes leaks reported by valgrind as below (before fix). After fix, this is no longer reported.

==195708== 120 bytes in 5 blocks are definitely lost in loss record 580 of 1,478
==195708==    at 0x4849013: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==195708==    by 0x216113: ScoringFunction::ScoringFunction(scoring_function_choice, std::vector<float, std::allocator<float> > const&) (scoring_function.h:50)
==195708==    by 0x206D06: Vina::set_forcefield() (vina.cpp:456)
....