### PR TITLE
Remove duplicated calculation of coordinates.

### DIFF
--- a/src/lib/monte_carlo.cpp
+++ b/src/lib/monte_carlo.cpp
@@ -60,12 +60,9 @@ void monte_carlo::operator()(model& m, output_container& out, const precalculate
 		if(step == 0 || metropolis_accept(tmp.e, candidate.e, temperature, generator)) {
 			tmp = candidate;
 
-			m.set(tmp.c); // FIXME? useless?
-
 			// FIXME only for very promising ones
 			if(tmp.e < best_e || out.size() < num_saved_mins) {
 				quasi_newton_par(m, p, ig, tmp, g, authentic_v, evalcount);
-				m.set(tmp.c); // FIXME? useless?
 				tmp.coords = m.get_heavy_atom_movable_coords();
 				add_to_output_container(out, tmp, min_rmsd, num_saved_mins); // 20 - max size
 				if(tmp.e < best_e)


### PR DESCRIPTION
In function `quasi_newton::operator()`, the model coordinates are always updated with the conformer searched from BFGS optimization.
https://github.com/ccsb-scripps/AutoDock-Vina/blob/350bb7f28d65265f1c86fa2362d0e469cad8b8fc/src/lib/quasi_newton.cpp#L43-L51

Thus, there is no need to calculate model coordinates in function `monte_carlo::operator()`.
https://github.com/ccsb-scripps/AutoDock-Vina/blob/350bb7f28d65265f1c86fa2362d0e469cad8b8fc/src/lib/monte_carlo.cpp#L59-L74

To ensure consistency, a test is executed between the base commit and the updated one. Bash commands are pasted below:
```bash
cd example/basic_docking/
time vina \
  --receptor solution/1iep_receptor.pdbqt \
  --ligand solution/1iep_ligand.pdbqt \
  --config solution/1iep_receptor_vina_box.txt \
  --exhaustiveness 16 \
  --seed 137 \
  --cpu 6 \
  --no_refine  # Observe the output of Monte-Carlo search
```

It can be verified that generated files `solution/1iep_ligand_out.pdbqt` are exactly alike.

With this pull request merged, we are convinced that CPU cost will be reduced slightly. My CPU type is `Intel(R) Xeon(R) Platinum 8336C CPU @ 2.30GHz` and average time of 10 runs are:
version | real | user | sys
-------- | ---- | ---- | ---
baseline | 33.83s | 180.47s | 0.37s
updated | 33.76s | 180.20s | 0.35s
