### PR TITLE
added libboost to source code install

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -49,7 +49,7 @@ The Anaconda Python distribution, which can be download from `https://docs.conti
 
 .. code-block:: bash
 
-    $ conda install -c conda-forge numpy swig boost-cpp sphinx sphinx_rtd_theme
+    $ conda install -c conda-forge numpy swig boost-cpp libboost sphinx sphinx_rtd_theme
     $ pip install vina
 
 Building from Source


### PR DESCRIPTION
Some systems may require explicit installation of libboost for installing the python bindings from source code, added that to the installation instructions.