### PR TITLE
Specify 3.9 version

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -41,7 +41,7 @@ The Anaconda Python distribution, which can be download from `https://docs.conti
 
 .. code-block:: bash
 
-    $ conda create -n vina python=3
+    $ conda create -n vina python=3.9
     $ conda activate vina
     $ conda config --env --add channels conda-forge
 


### PR DESCRIPTION
Avoids error running `pip install vina` with 3.10+

```
Collecting vina
  Using cached vina-1.2.5.tar.gz (89 kB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Requirement already satisfied: numpy>=1.18 in /Users/username/miniconda3/envs/vina/lib/python3.13t/site-packages (from vina) (2.2.1)
Building wheels for collected packages: vina
  Building wheel for vina (pyproject.toml) ... error
  error: subprocess-exited-with-error

  × Building wheel for vina (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [119 lines of output]
      fatal: not a git repository (or any of the parent directories): .git
      Version found 1.2.5 (from __init__.py)
      running bdist_wheel
      running build
      running build_ext
      Boost library location automatically determined in this conda environment.
      Boost library location was automatically guessed at /Users/username/miniconda3/envs/vina/include.
      - include_dirs: ['/Users/username/miniconda3/envs/vina/include/python3.13t', '/Users/username/miniconda3/envs/vina/include', 'src/lib']
      - library_dirs: ['/Users/username/miniconda3/envs/vina/lib']
      - swig options: ['-c++', '-small', '-naturalvar', '-fastdispatch', '-shadow', '-py3', '-I/Users/username/miniconda3/envs/vina/include/python3.13t', '-I/Users/username/miniconda3/envs/vina/include', '-Isrc/lib']
      - libraries: []
      - extra link args: ['-lboost_thread', '-lboost_serialization', '-lboost_filesystem', '-lboost_program_options', '-Wl,-rpath,/Users/username/miniconda3/envs/vina/lib', '-Wl,-rpath,/usr/lib']
      Warning: compiler flag -Wstrict-prototypes is not present, cannot remove it.
      - compiler options: ['g++', '-fno-strict-overflow', '-shared', '-Wsign-compare', '-Wunreachable-code', '-DNDEBUG', '-O2', '-fPIC', '-O2', '-isystem', '/Users/username/miniconda3/envs/vina/include', '-fPIC', '-O2', '-isystem', '/Users/username/miniconda3/envs/vina/include', '-std=c++11', '-Wno-long-long', '-pedantic', '-DBOOST_ERROR_CODE_HEADER_ONLY']
      building 'vina._vina_wrapper' extension
      swigging vina/autodock_vina.i to vina/autodock_vina_wrap.cpp
      swig -python -c++ -small -naturalvar -fastdispatch -shadow -py3 -I/Users/username/miniconda3/envs/vina/include/python3.13t -I/Users/username/miniconda3/envs/vina/include -Isrc/lib -o vina/autodock_vina_wrap.cpp vina/autodock_vina.i
      Deprecated command line option: -py3. Ignored, this option is no longer supported.
      creating build/temp.macosx-10.13-x86_64-cpython-313t/src/lib
      creating build/temp.macosx-10.13-x86_64-cpython-313t/vina
      clang++ -fno-strict-overflow -Wsign-compare -Wunreachable-code -DNDEBUG -O2 -Wall -fPIC -O2 -isystem /Users/username/miniconda3/envs/vina/include -fPIC -O2 -isystem /Users/username/miniconda3/envs/vina/include -I/Users/username/miniconda3/envs/vina/include/python3.13t -I/Users/username/miniconda3/envs/vina/include -Isrc/lib -c src/lib/ad4cache.cpp -o build/temp.macosx-10.13-x86_64-cpython-313t/src/lib/ad4cache.o
      In file included from src/lib/ad4cache.cpp:23:
      In file included from src/lib/ad4cache.h:32:
      In file included from /Users/username/miniconda3/envs/vina/include/boost/filesystem/fstream.hpp:17:
      In file included from /Users/username/miniconda3/envs/vina/include/boost/filesystem/path.hpp:34:
      In file included from /Users/username/miniconda3/envs/vina/include/boost/filesystem/detail/path_traits.hpp:26:
      In file included from /Users/username/miniconda3/envs/vina/include/boost/system/error_category.hpp:10:
      /Users/username/miniconda3/envs/vina/include/boost/system/detail/error_category.hpp:87:5: error: unknown type name 'constexpr'
         87 |     constexpr error_category() noexcept: id_( 0 ), stdcat_(), sc_init_()
            |     ^
      /Users/username/miniconda3/envs/vina/include/boost/system/detail/error_category.hpp:87:15: error: constructor cannot have a return type
         87 |     constexpr error_category() noexcept: id_( 0 ), stdcat_(), sc_init_()
            |               ^~~~~~~~~~~~~~
      /Users/username/miniconda3/envs/vina/include/boost/system/detail/error_category.hpp:87:31: error: expected ';' at end of declaration list
         87 |     constexpr error_category() noexcept: id_( 0 ), stdcat_(), sc_init_()
            |                               ^
      /Users/username/miniconda3/envs/vina/include/boost/system/detail/error_category.hpp:99:68: error: expected ';' at end of declaration list
         99 |     virtual error_condition default_error_condition( int ev ) const noexcept;
            |                                                                    ^
      /Users/username/miniconda3/envs/vina/include/boost/system/detail/error_category.hpp:100:81: error: expected ';' at end of declaration list
        100 |     virtual bool equivalent( int code, const error_condition & condition ) const noexcept;
            |                                                                                 ^
      /Users/username/miniconda3/envs/vina/include/boost/system/detail/error_category.hpp:101:76: error: expected ';' at end of declaration list
        101 |     virtual bool equivalent( const error_code & code, int condition ) const noexcept;
            |                                                                            ^
      /Users/username/miniconda3/envs/vina/include/boost/system/detail/error_category.hpp:104:81: error: expected ';' at end of declaration list
        104 |     virtual char const * message( int ev, char * buffer, std::size_t len ) const noexcept;
            |                                                                                 ^
      /Users/username/miniconda3/envs/vina/include/boost/system/detail/error_category.hpp:106:40: error: expected ';' at end of declaration list
        106 |     virtual bool failed( int ev ) const noexcept
            |           |                                        ^
      In file included from src/lib/ad4cache.cpp:23:
      In file included from src/lib/ad4cache.h:32:
      In file included from /Users/username/miniconda3/envs/vina/include/boost/filesystem/fstream.hpp:17:
      In file included from /Users/username/miniconda3/envs/vina/include/boost/filesystem/path.hpp:34:
      In file included from /Users/username/miniconda3/envs/vina/include/boost/filesystem/detail/path_traits.hpp:26:
      In file included from /Users/username/miniconda3/envs/vina/include/boost/system/error_category.hpp:11:
      In file included from /Users/username/miniconda3/envs/vina/include/boost/system/detail/error_category_impl.hpp:14:
      In file included from /Users/username/miniconda3/envs/vina/include/boost/system/detail/error_condition.hpp:14:
      In file included from /Users/username/miniconda3/envs/vina/include/boost/system/detail/generic_category.hpp:14:
      /Users/username/miniconda3/envs/vina/include/boost/system/detail/generic_category_message.hpp:71:94: error: expected function body after function declarator
         71 | inline char const * generic_error_category_message( int ev, char * buffer, std::size_t len ) noexcept
            |                                                                                              ^
      In file included from src/lib/ad4cache.cpp:23:
      In file included from src/lib/ad4cache.h:32:
      In file included from /Users/username/miniconda3/envs/vina/include/boost/filesystem/fstream.hpp:17:
      In file included from /Users/username/miniconda3/envs/vina/include/boost/filesystem/path.hpp:34:
      In file included from /Users/username/miniconda3/envs/vina/include/boost/filesystem/detail/path_traits.hpp:26:
      In file included from /Users/username/miniconda3/envs/vina/include/boost/system/error_category.hpp:11:
      In file included from /Users/username/miniconda3/envs/vina/include/boost/system/detail/error_category_impl.hpp:14:
      In file included from /Users/username/miniconda3/envs/vina/include/boost/system/detail/error_condition.hpp:14:
      /Users/username/miniconda3/envs/vina/include/boost/system/detail/generic_category.hpp:38:52: error: expected ';' at end of declaration list
         38 |     BOOST_SYSTEM_CONSTEXPR generic_error_category() noexcept:
            |                                                    ^
      /Users/username/miniconda3/envs/vina/include/boost/system/detail/generic_category.hpp:49:73: error: expected ';' at end of declaration list
         49 |     char const * message( int ev, char * buffer, std::size_t len ) const noexcept BOOST_OVERRIDE;
            |                                                                         ^
      /Users/username/miniconda3/envs/vina/include/boost/system/detail/generic_category.hpp:58:101: error: expected function body after function declarator
         58 | inline char const * generic_error_category::message( int ev, char * buffer, std::size_t len ) const noexcept
            |                                                                                                     ^
      /Users/username/miniconda3/envs/vina/include/boost/system/detail/generic_category.hpp:97:50: error: expected function body after function declarator
         97 | inline error_category const & generic_category() noexcept BOOST_SYMBOL_VISIBLE;
            |                                                  ^
      /Users/username/miniconda3/envs/vina/include/boost/system/detail/generic_category.hpp:100:50: error: expected function body after function declarator
        100 | inline error_category const & generic_category() noexcept
            |                                                  ^
      In file included from src/lib/ad4cache.cpp:23:
      In file included from src/lib/ad4cache.h:32:
      In file included from /Users/username/miniconda3/envs/vina/include/boost/filesystem/fstream.hpp:17:
      In file included from /Users/username/miniconda3/envs/vina/include/boost/filesystem/path.hpp:34:
      In file included from /Users/username/miniconda3/envs/vina/include/boost/filesystem/detail/path_traits.hpp:26:
      In file included from /Users/username/miniconda3/envs/vina/include/boost/system/error_category.hpp:11:
      In file included from /Users/username/miniconda3/envs/vina/include/boost/system/detail/error_category_impl.hpp:14:
      /Users/username/miniconda3/envs/vina/include/boost/system/detail/error_condition.hpp:53:42: error: expected ';' at end of declaration list
         53 |     boost::ulong_long_type cat_id() const noexcept
            |                                          ^
      In file included from src/lib/ad4cache.cpp:23:
      In file included from src/lib/ad4cache.h:32:
      In file included from /Users/username/miniconda3/envs/vina/include/boost/filesystem/fstream.hpp:17:
      In file included from /Users/username/miniconda3/envs/vina/include/boost/filesystem/path.hpp:34:
      In file included from /Users/username/miniconda3/envs/vina/include/boost/filesystem/detail/path_traits.hpp:26:
      In file included from /Users/username/miniconda3/envs/vina/include/boost/system/error_category.hpp:11:
      In file included from /Users/username/miniconda3/envs/vina/include/boost/system/detail/error_category_impl.hpp:15:
      In file included from /Users/username/miniconda3/envs/vina/include/boost/system/detail/error_code.hpp:16:
      /Users/username/miniconda3/envs/vina/include/boost/system/detail/system_category.hpp:37:51: error: expected ';' at end of declaration list
         37 |     BOOST_SYSTEM_CONSTEXPR system_error_category() noexcept:
            |                                                   ^
      /Users/username/miniconda3/envs/vina/include/boost/system/detail/system_category.hpp:50:73: error: expected ';' at end of declaration list
         50 |     char const * message( int ev, char * buffer, std::size_t len ) const noexcept BOOST_OVERRIDE;
            |                                                                         ^
      /Users/username/miniconda3/envs/vina/include/boost/system/detail/system_category.hpp:86:49: error: expected function body after function declarator
         86 | inline error_category const & system_category() noexcept BOOST_SYMBOL_VISIBLE;
            |                                                 ^
      /Users/username/miniconda3/envs/vina/include/boost/system/detail/system_category.hpp:89:49: error: expected function body after function declarator
         89 | inline error_category const & system_category() noexcept
            |                                                 ^
      fatal error: too many errors emitted, stopping now [-ferror-limit=]
 20 errors generated.
      error: command '/usr/bin/clang++' failed with exit code 1
      [end of output]
 
  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for vina
Failed to build vina
ERROR: ERROR: Failed to build installable wheels for some pyproject.toml based projects (vina)
```