### PR TITLE
Allow to omit --ligand and --batch when writing maps.

### DIFF
--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -329,8 +329,10 @@ Thank you!\n";
 		}
 
 		if (!vm.count("ligand") && !vm.count("batch")) {
-			std::cerr << desc_simple << "\n\nERROR: Missing ligand(s).\n";
-			exit(EXIT_FAILURE);
+			if (!vm.count("write_maps")) {
+				std::cerr << desc_simple << "\n\nERROR: Missing ligand(s) or --write_maps.\n";
+				exit(EXIT_FAILURE);
+			}
 		} else if (vm.count("ligand") && vm.count("batch")) {
 			std::cerr << desc_simple << "\n\nERROR: Can't use both --ligand and --batch arguments simultaneously.\n";
 			exit(EXIT_FAILURE);
@@ -408,10 +410,6 @@ Thank you!\n";
 			v.set_ad4_weights(weight_ad4_vdw, weight_ad4_hb, weight_ad4_elec,
 							  weight_ad4_dsolv, weight_glue, weight_ad4_rot);
 			v.load_maps(maps);
-
-			// It works, but why would you do this?!
-			if (vm.count("write_maps"))
-				v.write_maps(out_maps);
 		}
 
 		if (vm.count("ligand")) {
@@ -429,9 +427,9 @@ Thank you!\n";
 					} else {
 						v.compute_vina_maps(center_x, center_y, center_z, size_x, size_y, size_z, grid_spacing, force_even_voxels);
 					}
-
-					if (vm.count("write_maps"))
+					if (vm.count("write_maps")) {
 						v.write_maps(out_maps);
+					}
 				}
 			}
 
@@ -460,11 +458,15 @@ Thank you!\n";
 				if (vm.count("maps")) {
 					v.load_maps(maps);
 				} else {
-					// Will compute maps for all Vina atom types
-					v.compute_vina_maps(center_x, center_y, center_z, size_x, size_y, size_z, grid_spacing);
-
-					if (vm.count("write_maps"))
+					if ((score_only || local_only) && autobox) {
+						std::vector<double> dim = v.grid_dimensions_from_ligand(buffer_size);
+						v.compute_vina_maps(dim[0], dim[1], dim[2], dim[3], dim[4], dim[5], grid_spacing, force_even_voxels);
+					} else {
+						v.compute_vina_maps(center_x, center_y, center_z, size_x, size_y, size_z, grid_spacing, force_even_voxels);
+					}
+					if (vm.count("write_maps")) {
 						v.write_maps(out_maps);
+					}
 				}
 			}
 
@@ -528,6 +530,16 @@ Thank you!\n";
 			if (failed_ligand_parsing) {
 				std::cout << "Failed to parse " << failed_ligand_parsing << " ligands.\n";
 			}
+		} else if (vm.count("write_maps")) {
+			// Will compute maps only for Vina atom types in the ligand(s)
+			// In the case users ask for score and local only with the autobox arg, we compute the optimal box size for it/them.
+			if ((score_only || local_only) && autobox) {
+				std::vector<double> dim = v.grid_dimensions_from_ligand(buffer_size);
+				v.compute_vina_maps(dim[0], dim[1], dim[2], dim[3], dim[4], dim[5], grid_spacing, force_even_voxels);
+			} else {
+				v.compute_vina_maps(center_x, center_y, center_z, size_x, size_y, size_z, grid_spacing, force_even_voxels);
+			}
+			v.write_maps(out_maps);
 		}
 	}
 


### PR DESCRIPTION
There's some redundant code and it was barely tested.

May fix #382.