### PR TITLE
Fixed Github Actions workflows

### DIFF
--- a/.github/workflows/compile-binaries.yaml
+++ b/.github/workflows/compile-binaries.yaml
@@ -72,7 +72,7 @@ jobs:
           echo "DEBUG:: Checking Clang and xcode version"
           clang++ --version
           xcode-select --print-path
-          brew install boost@1.85 swig
+          brew install boost swig
           cd ./build/mac/release
           make
       - name: Compile Vina for Windows x64

--- a/.github/workflows/compile-binaries.yaml
+++ b/.github/workflows/compile-binaries.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - develop
+      - pip
     paths-ignore:
       - 'example/**'
       - 'docs/**'

--- a/.github/workflows/compile-binaries.yaml
+++ b/.github/workflows/compile-binaries.yaml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
       - develop
-      - pip
     paths-ignore:
       - 'example/**'
       - 'docs/**'
@@ -69,9 +68,6 @@ jobs:
       - name: Compile Vina for macOS
         if: matrix.os == 'macos-latest'
         run: |
-          echo "DEBUG:: Checking Clang and xcode version"
-          clang++ --version
-          xcode-select --print-path
           brew install boost swig
           cd ./build/mac/release
           make

--- a/.github/workflows/compile-binaries.yaml
+++ b/.github/workflows/compile-binaries.yaml
@@ -47,6 +47,7 @@ jobs:
       - name: Compile Vina for linux x86-64
         if: matrix.os == 'ubuntu-latest' && matrix.arch == 'x86_64'
         run: |
+          sudo apt-get update -y
           sudo apt-get install -y libboost-all-dev swig
           cd ./build/linux/release
           make
@@ -68,7 +69,10 @@ jobs:
       - name: Compile Vina for macOS
         if: matrix.os == 'macos-latest'
         run: |
-          brew install boost swig
+          echo "DEBUG:: Checking Clang and xcode version"
+          clang++ --version
+          xcode-select --print-path
+          brew install boost@1.85 swig
           cd ./build/mac/release
           make
       - name: Compile Vina for Windows x64

--- a/.github/workflows/pypi-build.yml
+++ b/.github/workflows/pypi-build.yml
@@ -50,6 +50,7 @@ jobs:
           platforms: arm64
       - name: Add tag to version.py file
         run: |
+          echo "jani debug, add tag to version.py file"
           git describe --abbrev=7 --dirty --always --tags | \
             sed 's/dirty/mod/g' | \
             sed 's/-/+/' | \
@@ -57,19 +58,21 @@ jobs:
             sed 's/v//' > ./build/python/vina/version.py
           cat ./build/python/vina/version.py
       - name: Install Python dependencies
-        run: python -m pip install build
-          #python -m pip install cibuildwheel==2.0.1
+        run: python -m pip install cibuildwheel setuptools wheel packaging
+      - name: Check setuptools version
+        run: |
+          echo "checking setuptools version"
+          python -c "import setuptools; print(setuptools.__version__)"
       - name: Build wheels
         run: |
           cp -R ./build/python/* .
-          python -m build 
-          # python -m cibuildwheel --output-dir wheelhouse
+          python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_SKIP: pp*
           CIBW_ARCHS: auto64
           CIBW_ARCHS_LINUX: ${{ matrix.arch }}
           CIBW_BEFORE_BUILD: |
-            pip install --upgrade pip setuptools
+            pip install --upgrade pip setuptools wheel packaging
           CIBW_BEFORE_ALL_MACOS: |
             brew install boost swig
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
@@ -79,6 +82,7 @@ jobs:
             sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
             yum clean all && yum -y update 
             yum install -y wget python-devel pcre-devel
+
             # Install SWIG
             wget https://downloads.sourceforge.net/swig/swig-4.0.2.tar.gz
             tar -xvf swig-4*.tar.gz 
@@ -86,17 +90,33 @@ jobs:
             ./configure --prefix=/usr --without-maximum-compile-warnings && make
             make install && install -v -m755 -d /usr/share/doc/swig-4.0.2 && cp -v -R Doc/* /usr/share/doc/swig-4.0.2
             cd ..
+
             # Install Boost
-            wget https://boostorg.jfrog.io/artifactory/main/release/1.75.0/source/boost_1_75_0.tar.gz
-            tar -xzf boost_1_*
-            cd boost_1_*
+            # echo "jani before installing boost"
+            # pwd
+            # ls 
+            # wget https://boostorg.jfrog.io/artifactory/main/release/1.75.0/source/boost_1_75_0.tar.gz
+            wget https://archives.boost.io/release/1.82.0/source/boost_1_82_0.tar.gz
+            # tar -xzf boost_1_*
+            tar -xzf boost_1_82_0.tar.gz
+            # cd boost_1_*
+            cd boost_1_82_0 
+            ls
             ./bootstrap.sh --prefix=/usr --with-python=python
             ./b2 install threading=multi link=shared
             cd ..
+            export CXXFLAGS="-I/usr/include"
+            export LDFLAGS="-L/usr/lib64"
+            echo "jani after installing boost"
+            cat /etc/os-release
+            pwd
+            ls project
+
             # Clean up
             rm -rf boost_1_*
             rm -rf swig-4*
       - name: Upload artifacts for inspection
+        if: ${{ env.ACT }} != 'true'  # Skip this step if running locally using 'act'
         uses: actions/upload-artifact@v4
         with:
           name: wheels
@@ -118,7 +138,8 @@ jobs:
           architecture: 'x64'
       - name: Install Python dependencies
         run: |
-          python -m pip install --upgrade pip setuptools
+          echo "jani debug, Install python deps in build-sdist"
+          python -m pip install --upgrade pip setuptools wheel packaging
       - name: Install boost-devel and swig
         run: |
           sudo apt-get install -y libboost-all-dev swig

--- a/.github/workflows/pypi-build.yml
+++ b/.github/workflows/pypi-build.yml
@@ -57,11 +57,13 @@ jobs:
             sed 's/v//' > ./build/python/vina/version.py
           cat ./build/python/vina/version.py
       - name: Install Python dependencies
-        run: python -m pip install cibuildwheel==2.0.1
+        run: python -m pip install build
+          #python -m pip install cibuildwheel==2.0.1
       - name: Build wheels
         run: |
           cp -R ./build/python/* .
-          python -m cibuildwheel --output-dir wheelhouse
+          python -m build 
+          # python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_SKIP: pp*
           CIBW_ARCHS: auto64

--- a/.github/workflows/pypi-build.yml
+++ b/.github/workflows/pypi-build.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
       - develop
-      - pip
     paths-ignore:
       - 'example/**'
       - 'docs/**'
@@ -92,9 +91,7 @@ jobs:
             # Install Boost
             # wget https://boostorg.jfrog.io/artifactory/main/release/1.75.0/source/boost_1_75_0.tar.gz
             wget https://archives.boost.io/release/1.82.0/source/boost_1_82_0.tar.gz
-            # tar -xzf boost_1_*
             tar -xzf boost_1_82_0.tar.gz
-            # cd boost_1_*
             cd boost_1_82_0 
             ls
             ./bootstrap.sh --prefix=/usr --with-python=python

--- a/.github/workflows/pypi-build.yml
+++ b/.github/workflows/pypi-build.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
       - develop
-      - pip
     paths-ignore:
       - 'example/**'
       - 'docs/**'
@@ -14,7 +13,6 @@ on:
     branches:
       - master
       - develop
-      - pip
     paths-ignore:
       - 'example/**'
       - 'docs/**'
@@ -50,7 +48,6 @@ jobs:
           platforms: arm64
       - name: Add tag to version.py file
         run: |
-          echo "jani debug, add tag to version.py file"
           git describe --abbrev=7 --dirty --always --tags | \
             sed 's/dirty/mod/g' | \
             sed 's/-/+/' | \
@@ -92,9 +89,6 @@ jobs:
             cd ..
 
             # Install Boost
-            # echo "jani before installing boost"
-            # pwd
-            # ls 
             # wget https://boostorg.jfrog.io/artifactory/main/release/1.75.0/source/boost_1_75_0.tar.gz
             wget https://archives.boost.io/release/1.82.0/source/boost_1_82_0.tar.gz
             # tar -xzf boost_1_*
@@ -107,10 +101,6 @@ jobs:
             cd ..
             export CXXFLAGS="-I/usr/include"
             export LDFLAGS="-L/usr/lib64"
-            echo "jani after installing boost"
-            cat /etc/os-release
-            pwd
-            ls project
 
             # Clean up
             rm -rf boost_1_*
@@ -138,7 +128,6 @@ jobs:
           architecture: 'x64'
       - name: Install Python dependencies
         run: |
-          echo "jani debug, Install python deps in build-sdist"
           python -m pip install --upgrade pip setuptools wheel packaging
       - name: Install boost-devel and swig
         run: |

--- a/.github/workflows/pypi-build.yml
+++ b/.github/workflows/pypi-build.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - develop
+      - pip
     paths-ignore:
       - 'example/**'
       - 'docs/**'

--- a/.github/workflows/pypi-build.yml
+++ b/.github/workflows/pypi-build.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - develop
+      - pip
     paths-ignore:
       - 'example/**'
       - 'docs/**'
@@ -13,6 +14,7 @@ on:
     branches:
       - master
       - develop
+      - pip
     paths-ignore:
       - 'example/**'
       - 'docs/**'

--- a/build/mac/release/Makefile
+++ b/build/mac/release/Makefile
@@ -3,7 +3,7 @@ BOOST_VERSION=
 BOOST_INCLUDE = $(BASE)/include
 C_PLATFORM=-pthread
 GPP=/usr/bin/clang++
-C_OPTIONS= -O3 -DNDEBUG -std=c++11 -fvisibility=hidden
+C_OPTIONS= -O3 -DNDEBUG -std=c++14 -fvisibility=hidden
 BOOST_LIB_VERSION=
 BOOST_STATIC=y
 

--- a/build/python/pyproject.toml
+++ b/build/python/pyproject.toml
@@ -1,3 +1,0 @@
-[build-system]
-requires = ["setuptools>=50.3", "wheel", "packaging"]
-build-backend = "setuptools.build_meta"

--- a/build/python/setup.py
+++ b/build/python/setup.py
@@ -317,7 +317,7 @@ obextension = Extension(
 
 setup(
     name='vina',
-    version=find_version(),
+    version="1.2.6", #find_version(),
     author='Diogo Santos Martins, Jerome Eberhardt, Andreas F. Tillack, Stefano Forli',
     author_email='forli@scripps.edu',
     license='Apache-2.0',

--- a/build/python/setup.py
+++ b/build/python/setup.py
@@ -329,7 +329,7 @@ setup(
     cmdclass={'build': CustomBuild, 'build_ext': CustomBuildExt, 'install': CustomInstall, 'sdist': CustomSdist},
     packages=['vina'],
     package_dir=package_dir,
-    install_requires=['numpy>=1.18'],
+    install_requires=['numpy>=1.18', "setuptools>=50.3", "wheel", "packaging"],
     python_requires='>=3.5',
     ext_modules=[obextension],
     #entry_points={"console_scripts": ["vina = vina.vina_cli:main"]},

--- a/build/python/setup.py
+++ b/build/python/setup.py
@@ -317,7 +317,7 @@ obextension = Extension(
 
 setup(
     name='vina',
-    version="1.2.6", #find_version(),
+    version=find_version(),
     author='Diogo Santos Martins, Jerome Eberhardt, Andreas F. Tillack, Stefano Forli',
     author_email='forli@scripps.edu',
     license='Apache-2.0',


### PR DESCRIPTION
Fixed the workflows in the github actions folder. Now the code should automatically compile and upload to pypi on release. This included: 

- Updating the URL used to download boost
- Updating the cibuildwheel version used for building
- Updating the macos release MAKEFILE to C++14 standard (otherwise latest boost wasn't working)
- Remove pyproject.toml. It doesn't really add anything right now. Perhaps a future release could upgrade to using a toml file instead of setup.py. 
