### PR TITLE
GA small fix: Force cross-compilation for mac x86_64 on arm64 runners, under Intel emulation

### DIFF
--- a/.github/workflows/compile-binaries.yaml
+++ b/.github/workflows/compile-binaries.yaml
@@ -70,7 +70,7 @@ jobs:
         run: |
           brew install boost swig
           cd ./build/mac/release
-          make
+          arch -x86_64 make
       - name: Compile Vina for macOS aarch64
         if: matrix.os == 'macos-latest' && matrix.arch == 'aarch64'
         run: |

--- a/.github/workflows/compile-binaries.yaml
+++ b/.github/workflows/compile-binaries.yaml
@@ -65,8 +65,14 @@ jobs:
           run: |
             cd /vina/build/linux/release
             make
-      - name: Compile Vina for macOS
-        if: matrix.os == 'macos-latest'
+      - name: Compile Vina for macOS x86_64
+        if: matrix.os == 'macos-latest' && matrix.arch == 'x86_64'
+        run: |
+          brew install boost swig
+          cd ./build/mac/release
+          make
+      - name: Compile Vina for macOS aarch64
+        if: matrix.os == 'macos-latest' && matrix.arch == 'aarch64'
         run: |
           brew install boost swig
           cd ./build/mac/release

--- a/.github/workflows/compile-binaries.yaml
+++ b/.github/workflows/compile-binaries.yaml
@@ -68,6 +68,9 @@ jobs:
       - name: Compile Vina for macOS x86_64
         if: matrix.os == 'macos-latest' && matrix.arch == 'x86_64'
         run: |
+          arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+          echo 'eval "$(/usr/local/bin/brew shellenv)"' >> ~/.bash_profile
+          eval "$(/usr/local/bin/brew shellenv)"
           arch -x86_64 brew install boost swig
           cd ./build/mac/release
           arch -x86_64 make

--- a/.github/workflows/compile-binaries.yaml
+++ b/.github/workflows/compile-binaries.yaml
@@ -68,7 +68,7 @@ jobs:
       - name: Compile Vina for macOS x86_64
         if: matrix.os == 'macos-latest' && matrix.arch == 'x86_64'
         run: |
-          brew install boost swig
+          arch -x86_64 brew install boost swig
           cd ./build/mac/release
           arch -x86_64 make
       - name: Compile Vina for macOS aarch64

--- a/.github/workflows/compile-binaries.yaml
+++ b/.github/workflows/compile-binaries.yaml
@@ -69,7 +69,6 @@ jobs:
         if: matrix.os == 'macos-latest' && matrix.arch == 'x86_64'
         run: |
           arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-          echo 'eval "$(/usr/local/bin/brew shellenv)"' >> ~/.bash_profile
           eval "$(/usr/local/bin/brew shellenv)"
           arch -x86_64 brew install boost swig
           cd ./build/mac/release


### PR DESCRIPTION
@joanimato Thanks for the fixes for GA. One minor problem with #385 was that both of the mac artifacts (from the arm64 and x86_64 workflows) have the arm64 architecture. This PR forces cross-compilation for the mac x86_64 executables to happen on arm64 runners, under Intel emulation. 

Please take a quick look at the small changes and let me know if I'm doing the right thing. I will add the complied executables to the release tab, once this is merged