### PR TITLE
Follow-up to #383

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.DS_Store
 *.o
+.vscode
 build/python/vina/autodock_vina_wrap.cpp
 build/python/vina/vina_wrapper.py
 build/python/vina.egg-info/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,0 @@
-{
-    "files.associations": {
-        "__bit_reference": "cpp",
-        "bitset": "cpp",
-        "set": "cpp",
-        "unordered_map": "cpp",
-        "iostream": "cpp"
-    }
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+    "files.associations": {
+        "__bit_reference": "cpp",
+        "bitset": "cpp",
+        "set": "cpp",
+        "unordered_map": "cpp",
+        "iostream": "cpp"
+    }
+}

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -328,11 +328,9 @@ Thank you!\n";
 			exit(EXIT_FAILURE);
 		}
 
-		if (!vm.count("ligand") && !vm.count("batch")) {
-			if (!vm.count("write_maps")) {
-				std::cerr << desc_simple << "\n\nERROR: Missing ligand(s) or --write_maps.\n";
-				exit(EXIT_FAILURE);
-			}
+		if (!vm.count("ligand") && !vm.count("batch") && !vm.count("write_maps")) {
+			std::cerr << desc_simple << "\n\nERROR: Missing ligand(s) or --write_maps.\n";
+			exit(EXIT_FAILURE);
 		} else if (vm.count("ligand") && vm.count("batch")) {
 			std::cerr << desc_simple << "\n\nERROR: Can't use both --ligand and --batch arguments simultaneously.\n";
 			exit(EXIT_FAILURE);

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -419,7 +419,7 @@ Thank you!\n";
 				} else {
 					// Will compute maps only for Vina atom types in the ligand(s)
 					// In the case users ask for score and local only with the autobox arg, we compute the optimal box size for it/them.
-					if (autobox) {
+					if ((score_only || local_only) && autobox) {
 						std::vector<double> dim = v.grid_dimensions_from_ligand(buffer_size);
 						v.compute_vina_maps(dim[0], dim[1], dim[2], dim[3], dim[4], dim[5], grid_spacing, force_even_voxels);
 					} else {
@@ -453,12 +453,8 @@ Thank you!\n";
 				if (vm.count("maps")) {
 					v.load_maps(maps);
 				} else {
-					// if ((score_only || local_only) && autobox) {
-					// 	std::vector<double> dim = v.grid_dimensions_from_ligand(buffer_size);
-					// 	v.compute_vina_maps(dim[0], dim[1], dim[2], dim[3], dim[4], dim[5], grid_spacing, force_even_voxels);
-					// } else {
-						v.compute_vina_maps(center_x, center_y, center_z, size_x, size_y, size_z, grid_spacing, force_even_voxels);
-					// }
+					// Batch mode is allowed only if not ad4?
+					v.compute_vina_maps(center_x, center_y, center_z, size_x, size_y, size_z, grid_spacing, force_even_voxels);
 				}
 			}
 

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -329,8 +329,10 @@ Thank you!\n";
 		}
 
 		if (!vm.count("ligand") && !vm.count("batch")) {
-			std::cerr << desc_simple << "\n\nERROR: Missing ligand(s).\n";
-			exit(EXIT_FAILURE);
+			if (!vm.count("write_maps")) {
+				std::cerr << desc_simple << "\n\nERROR: Missing ligand(s) or --write_maps.\n";
+				exit(EXIT_FAILURE);
+			}
 		} else if (vm.count("ligand") && vm.count("batch")) {
 			std::cerr << desc_simple << "\n\nERROR: Can't use both --ligand and --batch arguments simultaneously.\n";
 			exit(EXIT_FAILURE);
@@ -408,10 +410,6 @@ Thank you!\n";
 			v.set_ad4_weights(weight_ad4_vdw, weight_ad4_hb, weight_ad4_elec,
 							  weight_ad4_dsolv, weight_glue, weight_ad4_rot);
 			v.load_maps(maps);
-
-			// It works, but why would you do this?!
-			if (vm.count("write_maps"))
-				v.write_maps(out_maps);
 		}
 
 		if (vm.count("ligand")) {
@@ -429,9 +427,9 @@ Thank you!\n";
 					} else {
 						v.compute_vina_maps(center_x, center_y, center_z, size_x, size_y, size_z, grid_spacing, force_even_voxels);
 					}
-
-					if (vm.count("write_maps"))
+					if (vm.count("write_maps")) {
 						v.write_maps(out_maps);
+					}
 				}
 			}
 
@@ -460,11 +458,15 @@ Thank you!\n";
 				if (vm.count("maps")) {
 					v.load_maps(maps);
 				} else {
-					// Will compute maps for all Vina atom types
-					v.compute_vina_maps(center_x, center_y, center_z, size_x, size_y, size_z, grid_spacing);
-
-					if (vm.count("write_maps"))
+					if ((score_only || local_only) && autobox) {
+						std::vector<double> dim = v.grid_dimensions_from_ligand(buffer_size);
+						v.compute_vina_maps(dim[0], dim[1], dim[2], dim[3], dim[4], dim[5], grid_spacing, force_even_voxels);
+					} else {
+						v.compute_vina_maps(center_x, center_y, center_z, size_x, size_y, size_z, grid_spacing, force_even_voxels);
+					}
+					if (vm.count("write_maps")) {
 						v.write_maps(out_maps);
+					}
 				}
 			}
 
@@ -528,6 +530,16 @@ Thank you!\n";
 			if (failed_ligand_parsing) {
 				std::cout << "Failed to parse " << failed_ligand_parsing << " ligands.\n";
 			}
+		} else if (vm.count("write_maps")) {
+			// Will compute maps only for Vina atom types in the ligand(s)
+			// In the case users ask for score and local only with the autobox arg, we compute the optimal box size for it/them.
+			if ((score_only || local_only) && autobox) {
+				std::vector<double> dim = v.grid_dimensions_from_ligand(buffer_size);
+				v.compute_vina_maps(dim[0], dim[1], dim[2], dim[3], dim[4], dim[5], grid_spacing, force_even_voxels);
+			} else {
+				v.compute_vina_maps(center_x, center_y, center_z, size_x, size_y, size_z, grid_spacing, force_even_voxels);
+			}
+			v.write_maps(out_maps);
 		}
 	}
 

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -309,6 +309,11 @@ Thank you!\n";
 			exit(EXIT_FAILURE);
 		}
 
+		if (vm.count("maps") && vm.count("write_maps")) {
+			std::cerr << "ERROR: --maps (argument to specify the input maps) and --write_maps cannot be used together. \n";
+			exit(EXIT_FAILURE);
+		}
+
 		if (sf_name.compare("vina") == 0 || sf_name.compare("vinardo") == 0) {
 			if (!vm.count("receptor") && !vm.count("maps")) {
 				std::cerr << desc_simple << "ERROR: The receptor or affinity maps must be specified.\n";
@@ -425,10 +430,10 @@ Thank you!\n";
 					} else {
 						v.compute_vina_maps(center_x, center_y, center_z, size_x, size_y, size_z, grid_spacing, force_even_voxels);
 					}
+					
+					if (vm.count("write_maps"))
+					v.write_maps(out_maps);
 				}
-
-				if (vm.count("write_maps"))
-				v.write_maps(out_maps);
 			}
 
 			if (randomize_only) {

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -530,12 +530,7 @@ Thank you!\n";
 				std::cout << "Failed to parse " << failed_ligand_parsing << " ligands.\n";
 			}
 		} else if (vm.count("write_maps")) {
-			// Will compute maps only for Vina atom types in the ligand(s)
-			// In the case users ask for score and local only with the autobox arg, we compute the optimal box size for it/them.
-			if (!vm.count("receptor")) {
-				std::cerr << "ERROR: --receptor is required for --write_maps.\n";
-				exit(EXIT_FAILURE);
-			}
+			// Will compute maps for all Vina atom types
 			v.compute_vina_maps(center_x, center_y, center_z, size_x, size_y, size_z, grid_spacing, force_even_voxels);
 			v.write_maps(out_maps);
 		}

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -419,14 +419,11 @@ Thank you!\n";
 				} else {
 					// Will compute maps only for Vina atom types in the ligand(s)
 					// In the case users ask for score and local only with the autobox arg, we compute the optimal box size for it/them.
-					if ((score_only || local_only) && autobox) {
+					if (autobox) {
 						std::vector<double> dim = v.grid_dimensions_from_ligand(buffer_size);
 						v.compute_vina_maps(dim[0], dim[1], dim[2], dim[3], dim[4], dim[5], grid_spacing, force_even_voxels);
 					} else {
 						v.compute_vina_maps(center_x, center_y, center_z, size_x, size_y, size_z, grid_spacing, force_even_voxels);
-					}
-					if (vm.count("write_maps")) {
-						v.write_maps(out_maps);
 					}
 				}
 			}
@@ -456,15 +453,12 @@ Thank you!\n";
 				if (vm.count("maps")) {
 					v.load_maps(maps);
 				} else {
-					if ((score_only || local_only) && autobox) {
-						std::vector<double> dim = v.grid_dimensions_from_ligand(buffer_size);
-						v.compute_vina_maps(dim[0], dim[1], dim[2], dim[3], dim[4], dim[5], grid_spacing, force_even_voxels);
-					} else {
+					// if ((score_only || local_only) && autobox) {
+					// 	std::vector<double> dim = v.grid_dimensions_from_ligand(buffer_size);
+					// 	v.compute_vina_maps(dim[0], dim[1], dim[2], dim[3], dim[4], dim[5], grid_spacing, force_even_voxels);
+					// } else {
 						v.compute_vina_maps(center_x, center_y, center_z, size_x, size_y, size_z, grid_spacing, force_even_voxels);
-					}
-					if (vm.count("write_maps")) {
-						v.write_maps(out_maps);
-					}
+					// }
 				}
 			}
 
@@ -528,10 +522,13 @@ Thank you!\n";
 			if (failed_ligand_parsing) {
 				std::cout << "Failed to parse " << failed_ligand_parsing << " ligands.\n";
 			}
-		} else if (vm.count("write_maps")) {
+		}
+		
+		if (vm.count("write_maps")) {
 			// Will compute maps only for Vina atom types in the ligand(s)
 			// In the case users ask for score and local only with the autobox arg, we compute the optimal box size for it/them.
-			if ((score_only || local_only) && autobox) {
+			if (vm.count("ligand") && autobox) {
+				v.set_ligand_from_file(ligand_names);
 				std::vector<double> dim = v.grid_dimensions_from_ligand(buffer_size);
 				v.compute_vina_maps(dim[0], dim[1], dim[2], dim[3], dim[4], dim[5], grid_spacing, force_even_voxels);
 			} else {

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -430,9 +430,9 @@ Thank you!\n";
 					} else {
 						v.compute_vina_maps(center_x, center_y, center_z, size_x, size_y, size_z, grid_spacing, force_even_voxels);
 					}
-					
+
 					if (vm.count("write_maps"))
-					v.write_maps(out_maps);
+						v.write_maps(out_maps);
 				}
 			}
 

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -426,9 +426,9 @@ Thank you!\n";
 						v.compute_vina_maps(center_x, center_y, center_z, size_x, size_y, size_z, grid_spacing, force_even_voxels);
 					}
 				}
-				if (vm.count("write_maps")) {
-					v.write_maps(out_maps);
-				}
+
+				if (vm.count("write_maps"))
+				v.write_maps(out_maps);
 			}
 
 			if (randomize_only) {
@@ -456,10 +456,11 @@ Thank you!\n";
 				if (vm.count("maps")) {
 					v.load_maps(maps);
 				} else {
+					// Will compute maps for all Vina atom types
 					v.compute_vina_maps(center_x, center_y, center_z, size_x, size_y, size_z, grid_spacing, force_even_voxels);
-				}
-				if (vm.count("write_maps")) {
-					v.write_maps(out_maps);
+
+					if (vm.count("write_maps"))
+						v.write_maps(out_maps);
 				}
 			}
 

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -426,6 +426,9 @@ Thank you!\n";
 						v.compute_vina_maps(center_x, center_y, center_z, size_x, size_y, size_z, grid_spacing, force_even_voxels);
 					}
 				}
+				if (vm.count("write_maps")) {
+					v.write_maps(out_maps);
+				}
 			}
 
 			if (randomize_only) {
@@ -453,8 +456,10 @@ Thank you!\n";
 				if (vm.count("maps")) {
 					v.load_maps(maps);
 				} else {
-					// Batch mode is allowed only if not ad4?
 					v.compute_vina_maps(center_x, center_y, center_z, size_x, size_y, size_z, grid_spacing, force_even_voxels);
+				}
+				if (vm.count("write_maps")) {
+					v.write_maps(out_maps);
 				}
 			}
 
@@ -518,18 +523,14 @@ Thank you!\n";
 			if (failed_ligand_parsing) {
 				std::cout << "Failed to parse " << failed_ligand_parsing << " ligands.\n";
 			}
-		}
-		
-		if (vm.count("write_maps")) {
+		} else if (vm.count("write_maps")) {
 			// Will compute maps only for Vina atom types in the ligand(s)
 			// In the case users ask for score and local only with the autobox arg, we compute the optimal box size for it/them.
-			if (vm.count("ligand") && autobox) {
-				v.set_ligand_from_file(ligand_names);
-				std::vector<double> dim = v.grid_dimensions_from_ligand(buffer_size);
-				v.compute_vina_maps(dim[0], dim[1], dim[2], dim[3], dim[4], dim[5], grid_spacing, force_even_voxels);
-			} else {
-				v.compute_vina_maps(center_x, center_y, center_z, size_x, size_y, size_z, grid_spacing, force_even_voxels);
+			if (!vm.count("receptor")) {
+				std::cerr << "ERROR: --receptor is required for --write_maps.\n";
+				exit(EXIT_FAILURE);
 			}
+			v.compute_vina_maps(center_x, center_y, center_z, size_x, size_y, size_z, grid_spacing, force_even_voxels);
 			v.write_maps(out_maps);
 		}
 	}


### PR DESCRIPTION
Hi @diogomart 

Could you please take a quick look at this PR? It has the minimal edits to allow `--write_maps` without `--ligand` or `--batch`. 

Changes made: 

- A third mode (write maps only), has been added to trigger `--write_maps` when neither `--ligand` nor `--batch` mode is specified. 

- The `force_even_voxels` option is now passed to all `compute_vina_maps` function calls.

- `--write_maps` and `--maps` are now conflicting arguments
When ligands are absent, `--write_maps` requires an initialized receptor and box specifications, which currently needs to come from `--receptor`. Therefore, `--write_maps` and `--maps` are implicitly conflicting. A new error condition has been introduced to manage the conflict. 

- A very small update to .gitignore is added to ignore vscode files. 

Kudos to @pslacerda for leading the work. When this is in release, I will update the documentation. Thanks! 

