### PR TITLE
Increase the precision of affinity maps

### DIFF
--- a/src/lib/cache.cpp
+++ b/src/lib/cache.cpp
@@ -423,7 +423,7 @@ void cache::write(const std::string& out_prefix, const szv& atom_types, const st
 					{
 						VINA_FOR(x, m_grids[t].m_data.dim0())
 						{
-							out << std::setprecision(4) << m_grids[t].m_data(x, y, z) << "\n"; // slow?
+							out << std::setprecision(10) << m_grids[t].m_data(x, y, z) << "\n"; // slow?
 						} // x
 					} // y
 				} // z


### PR DESCRIPTION
Albeit don't implement full precision, it may fix #392 because I don't imagine needing any more than this and is pretty much unlikely the precision set here cause any defect or slowness.