### PR TITLE
Rewrite compile.bat and Update GA workflow to build binaries on Windows: Use Git Version, Use MSBuild, and Allow custom Boost and MSBuild paths

### DIFF
--- a/.github/workflows/compile-binaries.yaml
+++ b/.github/workflows/compile-binaries.yaml
@@ -36,7 +36,7 @@ jobs:
             arch: x86_64
           - os: macos-latest
             arch: aarch64
-          - os: windows-latest
+          - os: windows-2019
 
     steps:
       - name: Checkout
@@ -97,7 +97,7 @@ jobs:
 
           # Execute compile.bat (in cmd)
           cd .\build\windows
-          .\compile.bat
+          .\compile.bat Release x64 "C:\local\boost_1_83_0\lib32-msvc-14.2" "C:\local\boost_1_83_0\lib64-msvc-14.2"
         shell: powershell
       - name: Upload artifacts for inspection
         uses: actions/upload-artifact@v4

--- a/.github/workflows/compile-binaries.yaml
+++ b/.github/workflows/compile-binaries.yaml
@@ -95,8 +95,8 @@ jobs:
               choco install git -y --no-progress
           }
 
-          # Get ans pass Git version
-          echo "GIT_VERSION=$(git describe --abbrev=7 --dirty --always --tags 2>nul)" >> $GITHUB_ENV
+          # Get and pass Git version
+          echo "GIT_VERSION=$(git describe --abbrev=7 --dirty --always --tags 2>$null)" >> $env:GITHUB_ENV
 
           # Execute compile.bat (in cmd)
           cd .\build\windows

--- a/.github/workflows/compile-binaries.yaml
+++ b/.github/workflows/compile-binaries.yaml
@@ -95,8 +95,17 @@ jobs:
               choco install git -y --no-progress
           }
 
-          # Get and pass Git version
-          $env:GIT_VERSION = $(git describe --abbrev=7 --dirty --always --tags 2>$null) -replace "dirty", "mod"
+          # Fetch all tags
+          if ($(git rev-parse --is-shallow-repository) -eq "true") {
+              git fetch --prune --unshallow --tags 2>$null
+          } else {
+              git fetch --prune --tags 2>$null
+          }
+
+          # Get the nearest tag, fallback to commit hash if no tag exists
+          $env:GIT_VERSION = $(git describe --tags --abbrev=7 --dirty --always 2>$null)
+          
+          # Ensure fallback value if Git describe fails
           if (-not $env:GIT_VERSION) { $env:GIT_VERSION = "0.0.0-unknown" }
           echo "GIT_VERSION=$env:GIT_VERSION" >> $env:GITHUB_ENV
 

--- a/.github/workflows/compile-binaries.yaml
+++ b/.github/workflows/compile-binaries.yaml
@@ -100,7 +100,7 @@ jobs:
 
           # Execute compile.bat (in cmd)
           cd .\build\windows
-          .\compile.bat Release x64 "C:\local\boost_1_83_0\lib64-msvc-14.2" "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\amd64\MSBuild.exe" "$env:GIT_VERSION"
+          .\compile.bat Release x64 "C:\local\boost_1_83_0\lib64-msvc-14.2" "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\MSBuild.exe" "$env:GIT_VERSION"
         shell: powershell
       - name: Upload artifacts for inspection
         uses: actions/upload-artifact@v4

--- a/.github/workflows/compile-binaries.yaml
+++ b/.github/workflows/compile-binaries.yaml
@@ -97,7 +97,7 @@ jobs:
 
           # Execute compile.bat (in cmd)
           cd .\build\windows
-          .\compile.bat Release x64 "C:\local\boost_1_83_0\lib64-msvc-14.2" "C:\local\boost_1_83_0\lib64-msvc-14.2"
+          .\compile.bat Release x64 "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\amd64\MSBuild.exe" "C:\local\boost_1_83_0\lib64-msvc-14.2"
         shell: powershell
       - name: Upload artifacts for inspection
         uses: actions/upload-artifact@v4

--- a/.github/workflows/compile-binaries.yaml
+++ b/.github/workflows/compile-binaries.yaml
@@ -100,7 +100,7 @@ jobs:
 
           # Execute compile.bat (in cmd)
           cd .\build\windows
-          .\compile.bat Release x64 "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\amd64\MSBuild.exe" "C:\local\boost_1_83_0\lib64-msvc-14.2" "$env:GIT_VERSION"
+          .\compile.bat Release x64 "C:\local\boost_1_83_0\lib64-msvc-14.2" "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\amd64\MSBuild.exe" "$env:GIT_VERSION"
         shell: powershell
       - name: Upload artifacts for inspection
         uses: actions/upload-artifact@v4

--- a/.github/workflows/compile-binaries.yaml
+++ b/.github/workflows/compile-binaries.yaml
@@ -80,10 +80,10 @@ jobs:
           cd ./build/mac/release
           make
       - name: Compile Vina for Windows x64
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-2019'
         run: |
           # Download boost binary
-          $Url = "https://sourceforge.net/projects/boost/files/boost-binaries/1.83.0/boost_1_83_0-msvc-14.3-64.exe"
+          $Url = "https://sourceforge.net/projects/boost/files/boost-binaries/1.83.0/boost_1_83_0-msvc-14.2-64.exe"
           [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
           $wcl=(New-Object System.Net.WebClient)
           $wcl.Headers.Add("user-agent", "Wget/1.21.0")

--- a/.github/workflows/compile-binaries.yaml
+++ b/.github/workflows/compile-binaries.yaml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   compile_binaries:
-    name: Build wheels on ${{ matrix.os }} ${{ matrix.arch }}
+    name: Compile binaries on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -43,14 +43,14 @@ jobs:
         uses: actions/checkout@v4
         with: 
           fetch-depth: 0
-      - name: Compile Vina for Linux x86-64
+      - name: Compile Vina for linux x86-64
         if: matrix.os == 'ubuntu-latest' && matrix.arch == 'x86_64'
         run: |
           sudo apt-get update -y
           sudo apt-get install -y libboost-all-dev swig
           cd ./build/linux/release
           make
-      - name: Compile Vina for Linux aarch64
+      - name: Compile Vina for linux ${{ matrix.arch }}
         if: matrix.os == 'ubuntu-latest' && matrix.arch != 'x86_64'
         uses: uraimo/run-on-arch-action@v2
         with:

--- a/.github/workflows/compile-binaries.yaml
+++ b/.github/workflows/compile-binaries.yaml
@@ -90,8 +90,10 @@ jobs:
           $wcl.DownloadFile($Url, "$env:TEMP\boost.exe")
           Start-Process -Wait -FilePath "$env:TEMP\boost.exe" "/SILENT","/SP-","/SUPPRESSMSGBOXES"
           
-          # Install Git
-          winget install --id Git.Git -e --source winget
+          # Install Git using Chocolatey (if not already installed)
+          if (-Not (Get-Command git -ErrorAction SilentlyContinue)) {
+              choco install git -y --no-progress
+          }
 
           # Execute compile.bat (in cmd)
           cd .\build\windows

--- a/.github/workflows/compile-binaries.yaml
+++ b/.github/workflows/compile-binaries.yaml
@@ -36,7 +36,7 @@ jobs:
             arch: x86_64
           - os: macos-latest
             arch: aarch64
-          - os: windows-2019
+          - os: windows-latest
 
     steps:
       - name: Checkout
@@ -80,14 +80,20 @@ jobs:
           cd ./build/mac/release
           make
       - name: Compile Vina for Windows x64
-        if: matrix.os == 'windows-2019'
+        if: matrix.os == 'windows-latest'
         run: |
-          $Url = "https://sourceforge.net/projects/boost/files/boost-binaries/1.77.0/boost_1_77_0-msvc-14.2-64.exe"
+          # Download boost binary
+          $Url = "https://sourceforge.net/projects/boost/files/boost-binaries/1.83.0/boost_1_83_0-msvc-14.3-64.exe"
           [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
           $wcl=(New-Object System.Net.WebClient)
           $wcl.Headers.Add("user-agent", "Wget/1.21.0")
           $wcl.DownloadFile($Url, "$env:TEMP\boost.exe")
           Start-Process -Wait -FilePath "$env:TEMP\boost.exe" "/SILENT","/SP-","/SUPPRESSMSGBOXES"
+          
+          # Install Git
+          winget install --id Git.Git -e --source winget
+
+          # Execute compile.bat (in cmd)
           cd .\build\windows
           .\compile.bat
         shell: powershell

--- a/.github/workflows/compile-binaries.yaml
+++ b/.github/workflows/compile-binaries.yaml
@@ -96,7 +96,7 @@ jobs:
           }
 
           # Get and pass Git version
-          echo "GIT_VERSION=$(git describe --abbrev=7 --dirty --always --tags 2>$null)" >> $env:GITHUB_ENV
+          $GIT_VERSION = git describe --abbrev=7 --dirty --always --tags 2>$null
 
           # Execute compile.bat (in cmd)
           cd .\build\windows

--- a/.github/workflows/compile-binaries.yaml
+++ b/.github/workflows/compile-binaries.yaml
@@ -96,7 +96,9 @@ jobs:
           }
 
           # Get and pass Git version
-          $GIT_VERSION = git describe --abbrev=7 --dirty --always --tags 2>$null
+          $env:GIT_VERSION = $(git describe --abbrev=7 --dirty --always --tags 2>$null) -replace "dirty", "mod"
+          if (-not $env:GIT_VERSION) { $env:GIT_VERSION = "0.0.0-unknown" }
+          echo "GIT_VERSION=$env:GIT_VERSION" >> $env:GITHUB_ENV
 
           # Execute compile.bat (in cmd)
           cd .\build\windows

--- a/.github/workflows/compile-binaries.yaml
+++ b/.github/workflows/compile-binaries.yaml
@@ -97,7 +97,7 @@ jobs:
 
           # Execute compile.bat (in cmd)
           cd .\build\windows
-          .\compile.bat Release x64 "C:\local\boost_1_83_0\lib32-msvc-14.2" "C:\local\boost_1_83_0\lib64-msvc-14.2"
+          .\compile.bat Release x64 "C:\local\boost_1_83_0\lib64-msvc-14.2" "C:\local\boost_1_83_0\lib64-msvc-14.2"
         shell: powershell
       - name: Upload artifacts for inspection
         uses: actions/upload-artifact@v4

--- a/.github/workflows/compile-binaries.yaml
+++ b/.github/workflows/compile-binaries.yaml
@@ -95,9 +95,12 @@ jobs:
               choco install git -y --no-progress
           }
 
+          # Get ans pass Git version
+          echo "GIT_VERSION=$(git describe --abbrev=7 --dirty --always --tags 2>nul)" >> $GITHUB_ENV
+
           # Execute compile.bat (in cmd)
           cd .\build\windows
-          .\compile.bat Release x64 "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\amd64\MSBuild.exe" "C:\local\boost_1_83_0\lib64-msvc-14.2"
+          .\compile.bat Release x64 "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\amd64\MSBuild.exe" "C:\local\boost_1_83_0\lib64-msvc-14.2" "$env:GIT_VERSION"
         shell: powershell
       - name: Upload artifacts for inspection
         uses: actions/upload-artifact@v4

--- a/.github/workflows/compile-binaries.yaml
+++ b/.github/workflows/compile-binaries.yaml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   compile_binaries:
-    name: Compile binaries on ${{ matrix.os }}
+    name: Compile binaries on ${{ matrix.os }} ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -37,6 +37,7 @@ jobs:
           - os: macos-latest
             arch: aarch64
           - os: windows-2019
+            arch: x64
 
     steps:
       - name: Checkout
@@ -51,7 +52,7 @@ jobs:
           cd ./build/linux/release
           make
       - name: Compile Vina for linux ${{ matrix.arch }}
-        if: matrix.os == 'ubuntu-latest' && matrix.arch != 'x86_64'
+        if: matrix.os == 'ubuntu-latest' && matrix.arch == 'aarch64'
         uses: uraimo/run-on-arch-action@v2
         with:
           arch: ${{ matrix.arch }}
@@ -80,7 +81,7 @@ jobs:
           cd ./build/mac/release
           make
       - name: Compile Vina for Windows x64
-        if: matrix.os == 'windows-2019'
+        if: matrix.os == 'windows-2019' && matrix.arch == 'x64'
         run: |
           # Download boost binary
           $Url = "https://sourceforge.net/projects/boost/files/boost-binaries/1.83.0/boost_1_83_0-msvc-14.2-64.exe"

--- a/build/windows/compile.bat
+++ b/build/windows/compile.bat
@@ -70,8 +70,8 @@ if NOT exist "%msbuild_path%" (
 echo Using MSBuild: "%msbuild_path%"
 
 :: Retrieve Git Version
-set GIT_VERSION=0.0.0-unknown
-for /f %%i in ('git describe --abbrev=7 --dirty --always --tags 2^>nul') do set GIT_VERSION=%%i
+if NOT "%~5"=="" set "GIT_VERSION=%~5"
+if "%GIT_VERSION%"=="" set GIT_VERSION=0.0.0-unknown
 
 :: Print Git Version
 echo Program Version from Git: "%GIT_VERSION%"

--- a/build/windows/compile.bat
+++ b/build/windows/compile.bat
@@ -1,10 +1,81 @@
 @echo off
+setlocal enabledelayedexpansion
 
-set target="Release|x64"
-IF "%~1"=="" GOTO noparms
-set target="%~1"
-:noparms
+:: Default settings
+set config=Release
+set platform=x64
 
-for /f "usebackq delims=" %%s in (`"%programfiles(x86)%\Microsoft Visual Studio\Installer\vswhere" -latest -property installationPath`) do set devenv="%%s\Common7\IDE\devenv.com"
+:: Default location of MSBuild.exe
+set msbuild_path="C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin\amd64\MSBuild.exe"
 
-%devenv% AutoDock-Vina.sln /Build %target%
+:: Allow user to override with command-line arguments
+if NOT "%~1"=="" set config=%~1
+if NOT "%~2"=="" set platform=%~2
+
+:: Check if Boost library is provided
+if NOT "%~3"=="" (
+    set boost_lib=%~3
+) else (
+    :: Default Boost library path based on choice of platform
+    if /i "%platform%"=="x64" (
+        set boost_lib=C:\local\boost_1_83_0\lib64-msvc-14.3
+    ) else (
+        set boost_lib=C:\local\boost_1_83_0\lib32-msvc-14.3
+    )
+)
+
+:: Validate Boost library path
+if NOT exist "%boost_lib%" (
+    echo ERROR: Boost library files not found at "%boost_lib%" for %platform%!
+    exit /b 1
+)
+echo Using Boost library: "%boost_lib%"
+
+:: Check if MSBuild path is provided
+if NOT "%~4"=="" (
+    set msbuild_path=%~4
+)
+
+:: Validate MSBuild path
+if NOT exist "%msbuild_path%" (
+    echo WARNING: MSBuild not found at "%msbuild_path%". Searching...
+
+    set msbuild_path=
+
+    :: Define possible search locations
+    set search_dirs="%ProgramFiles(x86)%" "%ProgramFiles%" "%LocalAppData%"
+    set expect_paths=MSBuild\Current\Bin\amd64\MSBuild.exe
+
+    if /i "%platform%" NEQ "x64" set expect_paths=MSBuild\Current\Bin\MSBuild.exe
+
+    :: Loop through search directories to find MSBuild
+    for %%D in (%search_dirs%) do (
+        for /f "delims=" %%A in ('cmd /c dir "%%D\Microsoft Visual Studio\" /s /b 2^>nul') do (
+            if exist "%%A\%expect_paths%" (
+                set "msbuild_path=%%A\%expect_paths%"
+                goto found
+            )
+        )
+    )
+
+    :: If MSBuild.exe is not found
+    if not defined msbuild_path (
+        echo ERROR: MSBuild.exe not found for %platform%!
+        exit /b 1
+    )
+)
+
+:: If MSBuild.exe is found
+:found
+echo Using MSBuild: "%msbuild_path%"
+
+:: Retrieve Git Version
+set GIT_VERSION=0.0.0-unknown
+for /f %%i in ('git describe --abbrev=7 --dirty --always --tags 2^>nul') do set GIT_VERSION=%%i
+
+:: Print Git Version
+echo Program Version from Git: "%GIT_VERSION%"
+
+:: Run MSBuild
+call "%msbuild_path%" AutoDock-Vina.sln /p:Configuration=%config% /p:Platform=%platform% /p:BoostLibraryPath="%boost_lib%" /p:GIT_VERSION="%GIT_VERSION%" /m
+endlocal

--- a/build/windows/compile.bat
+++ b/build/windows/compile.bat
@@ -6,7 +6,7 @@ set config=Release
 set platform=x64
 
 :: Default location of MSBuild.exe
-set msbuild_path="C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin\amd64\MSBuild.exe"
+set "msbuild_path=C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin\amd64\MSBuild.exe"
 
 :: Allow user to override with command-line arguments
 if NOT "%~1"=="" set config=%~1

--- a/build/windows/compile.bat
+++ b/build/windows/compile.bat
@@ -14,7 +14,7 @@ if NOT "%~2"=="" set platform=%~2
 
 :: Check if Boost library is provided
 if NOT "%~3"=="" (
-    set boost_lib=%~3
+    set "boost_lib=%~3"
 ) else (
     :: Default Boost library path based on choice of platform
     if /i "%platform%"=="x64" (
@@ -33,7 +33,7 @@ echo Using Boost library: "%boost_lib%"
 
 :: Check if MSBuild path is provided
 if NOT "%~4"=="" (
-    set msbuild_path=%~4
+    set "msbuild_path=%~4"
 )
 
 :: Validate MSBuild path

--- a/build/windows/compile.bat
+++ b/build/windows/compile.bat
@@ -44,16 +44,17 @@ if NOT exist "%msbuild_path%" (
 
     :: Define possible search locations
     set search_dirs="%ProgramFiles(x86)%" "%ProgramFiles%" "%LocalAppData%"
-    set expect_paths=MSBuild\Current\Bin\amd64\MSBuild.exe
-
-    if /i "%platform%" NEQ "x64" set expect_paths=MSBuild\Current\Bin\MSBuild.exe
+    set expect_paths="MSBuild\Current\Bin\MSBuild.exe"
+    if /i "%platform%" EQ "x64" set expect_paths="MSBuild\Current\Bin\amd64\MSBuild.exe" "MSBuild\Current\Bin\MSBuild.exe"
 
     :: Loop through search directories to find MSBuild
     for %%D in (%search_dirs%) do (
-        for /f "delims=" %%A in ('cmd /c dir "%%D\Microsoft Visual Studio\" /s /b 2^>nul') do (
-            if exist "%%A\%expect_paths%" (
-                set "msbuild_path=%%A\%expect_paths%"
-                goto found
+        for %%P in (%expect_paths%) do (
+            for /f "delims=" %%A in ('cmd /c dir "%%D\Microsoft Visual Studio\" /s /b 2^>nul') do (
+                if exist "%%A\%expect_paths%" (
+                    set "msbuild_path=%%A\%expect_paths%"
+                    goto found
+                )
             )
         )
     )

--- a/build/windows/compile.bat
+++ b/build/windows/compile.bat
@@ -42,10 +42,12 @@ if NOT exist "%msbuild_path%" (
 
     set msbuild_path=
 
-    :: Define possible search locations
-    set search_dirs="%ProgramFiles(x86)%" "%ProgramFiles%" "%LocalAppData%"
-    set expect_paths="MSBuild\Current\Bin\MSBuild.exe"
-    if /i "%platform%" EQ "x64" set expect_paths="MSBuild\Current\Bin\amd64\MSBuild.exe" "MSBuild\Current\Bin\MSBuild.exe"
+:: Define possible search locations
+set "search_dirs=%ProgramFiles(x86)% %ProgramFiles% %LocalAppData%"
+
+:: Define expected MSBuild paths
+set "expect_paths=MSBuild\Current\Bin\MSBuild.exe"
+if /i "%platform%"=="x64" set "expect_paths=MSBuild\Current\Bin\amd64\MSBuild.exe MSBuild\Current\Bin\MSBuild.exe"
 
     :: Loop through search directories to find MSBuild
     for %%D in (%search_dirs%) do (

--- a/build/windows/vina.vcxproj
+++ b/build/windows/vina.vcxproj
@@ -160,7 +160,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;VERSION="$(GIT_VERSION)";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(BoostRootPath)\boost;..\..\src\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(BoostRootPath);..\..\src\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <ConformanceMode>true</ConformanceMode>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <DisableSpecificWarnings>4244;4267</DisableSpecificWarnings>

--- a/build/windows/vina.vcxproj
+++ b/build/windows/vina.vcxproj
@@ -54,7 +54,6 @@
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
-  </PropertyGroup>
   <PropertyGroup>
     <BoostRootPath>$([System.IO.Path]::GetDirectoryName($(BoostLibraryPath)))</BoostRootPath>
   </PropertyGroup>

--- a/build/windows/vina.vcxproj
+++ b/build/windows/vina.vcxproj
@@ -54,6 +54,10 @@
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
+  </PropertyGroup>
+  <PropertyGroup>
+    <BoostRootPath>$([System.IO.Path]::GetDirectoryName($(BoostLibraryPath)))</BoostRootPath>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
@@ -97,7 +101,7 @@
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;VERSION="$(GIT_VERSION)";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(BoostRootPath)\boost;..\..\src\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(BoostIncludePath);..\..\src\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <ConformanceMode>true</ConformanceMode>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <DisableSpecificWarnings>4244;4267</DisableSpecificWarnings>
@@ -117,7 +121,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;VERSION="$(GIT_VERSION)";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(BoostRootPath)\boost;..\..\src\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(BoostIncludePath);..\..\src\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <ConformanceMode>true</ConformanceMode>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <DisableSpecificWarnings>4244;4267</DisableSpecificWarnings>
@@ -137,7 +141,7 @@
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;VERSION="$(GIT_VERSION)";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(BoostRootPath)\boost;..\..\src\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(BoostIncludePath);..\..\src\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <ConformanceMode>true</ConformanceMode>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <DisableSpecificWarnings>4244;4267</DisableSpecificWarnings>

--- a/build/windows/vina.vcxproj
+++ b/build/windows/vina.vcxproj
@@ -31,26 +31,26 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/build/windows/vina.vcxproj
+++ b/build/windows/vina.vcxproj
@@ -96,8 +96,8 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;VERSION="v1.2.5";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>C:\local\boost_1_77_0;..\..\src\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;VERSION="$(GIT_VERSION)";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(BoostRootPath);..\..\src\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <ConformanceMode>true</ConformanceMode>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <DisableSpecificWarnings>4244;4267</DisableSpecificWarnings>
@@ -106,7 +106,7 @@
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
-      <AdditionalLibraryDirectories>C:\local\boost_1_77_0\lib32-msvc-14.2;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(BoostLibraryPath);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
   </ItemDefinitionGroup>
@@ -116,8 +116,8 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;VERSION="v1.2.5";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>C:\local\boost_1_77_0;..\..\src\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;VERSION="$(GIT_VERSION)";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(BoostRootPath);..\..\src\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <ConformanceMode>true</ConformanceMode>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <DisableSpecificWarnings>4244;4267</DisableSpecificWarnings>
@@ -126,7 +126,7 @@
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
-      <AdditionalLibraryDirectories>C:\local\boost_1_77_0\lib32-msvc-14.2;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(BoostLibraryPath);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -136,8 +136,8 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;VERSION="v1.2.5";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>C:\local\boost_1_77_0;..\..\src\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;VERSION="$(GIT_VERSION)";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(BoostRootPath);..\..\src\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <ConformanceMode>true</ConformanceMode>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <DisableSpecificWarnings>4244;4267</DisableSpecificWarnings>
@@ -146,7 +146,7 @@
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
-      <AdditionalLibraryDirectories>C:\local\boost_1_77_0\lib64-msvc-14.2;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(BoostLibraryPath);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
   </ItemDefinitionGroup>
@@ -156,8 +156,8 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;VERSION="v1.2.5";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>C:\local\boost_1_77_0;..\..\src\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;VERSION="$(GIT_VERSION)";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(BoostRootPath);..\..\src\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <ConformanceMode>true</ConformanceMode>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <DisableSpecificWarnings>4244;4267</DisableSpecificWarnings>
@@ -166,7 +166,7 @@
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
-      <AdditionalLibraryDirectories>C:\local\boost_1_77_0\lib64-msvc-14.2;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(BoostLibraryPath);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/build/windows/vina.vcxproj
+++ b/build/windows/vina.vcxproj
@@ -97,7 +97,7 @@
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;VERSION="$(GIT_VERSION)";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(BoostRootPath);..\..\src\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(BoostRootPath)\boost;..\..\src\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <ConformanceMode>true</ConformanceMode>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <DisableSpecificWarnings>4244;4267</DisableSpecificWarnings>
@@ -117,7 +117,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;VERSION="$(GIT_VERSION)";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(BoostRootPath);..\..\src\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(BoostRootPath)\boost;..\..\src\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <ConformanceMode>true</ConformanceMode>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <DisableSpecificWarnings>4244;4267</DisableSpecificWarnings>
@@ -137,7 +137,7 @@
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;VERSION="$(GIT_VERSION)";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(BoostRootPath);..\..\src\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(BoostRootPath)\boost;..\..\src\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <ConformanceMode>true</ConformanceMode>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <DisableSpecificWarnings>4244;4267</DisableSpecificWarnings>
@@ -157,7 +157,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;VERSION="$(GIT_VERSION)";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(BoostRootPath);..\..\src\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(BoostRootPath)\boost;..\..\src\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <ConformanceMode>true</ConformanceMode>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <DisableSpecificWarnings>4244;4267</DisableSpecificWarnings>

--- a/build/windows/vina_split.vcxproj
+++ b/build/windows/vina_split.vcxproj
@@ -99,7 +99,7 @@
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;VERSION="$(GIT_VERSION)";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(BoostRootPath)\boost;..\..\src\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(BoostRootPath);..\..\src\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <ConformanceMode>true</ConformanceMode>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <DisableSpecificWarnings>4244;4267</DisableSpecificWarnings>
@@ -119,7 +119,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;VERSION="$(GIT_VERSION)%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(BoostRootPath)\boost;..\..\src\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(BoostRootPath);..\..\src\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <ConformanceMode>true</ConformanceMode>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <DisableSpecificWarnings>4244;4267</DisableSpecificWarnings>
@@ -139,7 +139,7 @@
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;VERSION="$(GIT_VERSION)";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(BoostRootPath)\boost;..\..\src\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(BoostRootPath);..\..\src\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <ConformanceMode>true</ConformanceMode>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <DisableSpecificWarnings>4244;4267</DisableSpecificWarnings>
@@ -159,7 +159,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;VERSION="$(GIT_VERSION)";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(BoostRootPath)\boost;..\..\src\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(BoostRootPath);..\..\src\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <ConformanceMode>true</ConformanceMode>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <DisableSpecificWarnings>4244;4267</DisableSpecificWarnings>

--- a/build/windows/vina_split.vcxproj
+++ b/build/windows/vina_split.vcxproj
@@ -91,12 +91,15 @@
     <IntDir>release\</IntDir>
     <OutDir>$(SolutionDir)\release\</OutDir>
   </PropertyGroup>
+  <PropertyGroup>
+    <BoostRootPath>$([System.IO.Path]::GetDirectoryName($(BoostLibraryPath)))</BoostRootPath>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;VERSION="v1.2.5";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>C:\local\boost_1_77_0;..\..\src\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;VERSION="$(GIT_VERSION)";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(BoostRootPath);..\..\src\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <ConformanceMode>true</ConformanceMode>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <DisableSpecificWarnings>4244;4267</DisableSpecificWarnings>
@@ -105,7 +108,7 @@
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
-      <AdditionalLibraryDirectories>C:\local\boost_1_77_0\lib32-msvc-14.2;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(BoostLibraryPath);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
   </ItemDefinitionGroup>
@@ -115,8 +118,8 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;VERSION="v1.2.5%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>C:\local\boost_1_77_0;..\..\src\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;VERSION="$(GIT_VERSION)%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(BoostRootPath);..\..\src\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <ConformanceMode>true</ConformanceMode>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <DisableSpecificWarnings>4244;4267</DisableSpecificWarnings>
@@ -125,7 +128,7 @@
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
-      <AdditionalLibraryDirectories>C:\local\boost_1_77_0\lib32-msvc-14.2;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(BoostLibraryPath);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -135,8 +138,8 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;VERSION="v1.2.5";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>C:\local\boost_1_77_0;..\..\src\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;VERSION="$(GIT_VERSION)";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(BoostRootPath);..\..\src\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <ConformanceMode>true</ConformanceMode>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <DisableSpecificWarnings>4244;4267</DisableSpecificWarnings>
@@ -145,7 +148,7 @@
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
-      <AdditionalLibraryDirectories>C:\local\boost_1_77_0\lib64-msvc-14.2;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(BoostLibraryPath);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
   </ItemDefinitionGroup>
@@ -155,8 +158,8 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;VERSION="v1.2.5";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>C:\local\boost_1_77_0;..\..\src\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;VERSION="$(GIT_VERSION)";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(BoostRootPath);..\..\src\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <ConformanceMode>true</ConformanceMode>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <DisableSpecificWarnings>4244;4267</DisableSpecificWarnings>
@@ -165,7 +168,7 @@
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
-      <AdditionalLibraryDirectories>C:\local\boost_1_77_0\lib64-msvc-14.2;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(BoostLibraryPath);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/build/windows/vina_split.vcxproj
+++ b/build/windows/vina_split.vcxproj
@@ -99,7 +99,7 @@
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;VERSION="$(GIT_VERSION)";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(BoostRootPath);..\..\src\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(BoostRootPath)\boost;..\..\src\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <ConformanceMode>true</ConformanceMode>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <DisableSpecificWarnings>4244;4267</DisableSpecificWarnings>
@@ -119,7 +119,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;VERSION="$(GIT_VERSION)%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(BoostRootPath);..\..\src\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(BoostRootPath)\boost;..\..\src\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <ConformanceMode>true</ConformanceMode>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <DisableSpecificWarnings>4244;4267</DisableSpecificWarnings>
@@ -139,7 +139,7 @@
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;VERSION="$(GIT_VERSION)";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(BoostRootPath);..\..\src\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(BoostRootPath)\boost;..\..\src\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <ConformanceMode>true</ConformanceMode>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <DisableSpecificWarnings>4244;4267</DisableSpecificWarnings>
@@ -159,7 +159,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;VERSION="$(GIT_VERSION)";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(BoostRootPath);..\..\src\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(BoostRootPath)\boost;..\..\src\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <ConformanceMode>true</ConformanceMode>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <DisableSpecificWarnings>4244;4267</DisableSpecificWarnings>

--- a/build/windows/vina_split.vcxproj
+++ b/build/windows/vina_split.vcxproj
@@ -30,26 +30,26 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>


### PR DESCRIPTION
This is a renovation of current build approach on Windows. To address Issue #390. 

Expect to add an installation note in doc for people who want to build binaries on Windows. 