### PR TITLE
Add macos build support for pypi

### DIFF
--- a/.github/workflows/pypi-build.yml
+++ b/.github/workflows/pypi-build.yml
@@ -55,12 +55,20 @@ jobs:
           platforms: arm64 
       - name: Add tag to version.py file
         run: |
-          git describe --abbrev=7 --dirty --always --tags | \
-            sed 's/dirty/mod/g' | \
-            sed 's/-/+/' | \
-            sed 's/-/./g' | \
-            sed 's/v//' > ./build/python/vina/version.py
-          cat ./build/python/vina/version.py
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            $version = git describe --abbrev=7 --dirty --always --tags
+            $version = $version -replace "dirty", "mod"
+            $version = $version -replace "-", "+"
+            $version = $version -replace "-", "."
+            $version = $version -replace "v", ""
+            Set-Content -Path .\build\python\vina\version.py -Value $version
+          else: 
+            git describe --abbrev=7 --dirty --always --tags | \
+              sed 's/dirty/mod/g' | \
+              sed 's/-/+/' | \
+              sed 's/-/./g' | \
+              sed 's/v//' > ./build/python/vina/version.py
+            cat ./build/python/vina/version.py
       - name: Install Python dependencies
         run: python -m pip install cibuildwheel setuptools wheel packaging
       - name: Check setuptools version
@@ -100,7 +108,7 @@ jobs:
             brew install boost swig
           CIBW_BEFORE_ALL_WINDOWS: |
             choco install -y swig boost-msvc-14.2
-            
+
       - name: Upload artifacts for inspection
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/pypi-build.yml
+++ b/.github/workflows/pypi-build.yml
@@ -89,21 +89,21 @@ jobs:
         run: |
           brew install boost swig
       - name: Install dependencies (Windows)
-        if: runner.os == 'Windows'
-        run: |
-          choco install -y swig boost-msvc-14.2
-          echo "Boost and SWIG installed"
+        # if: runner.os == 'Windows'
+        # run: |
+        #   choco install -y swig boost-msvc-14.2
+        #   echo "Boost and SWIG installed"
 
-          ls "C:\local\"
+        #   ls "C:\local\"
 
-          # Set BOOST_ROOT manually
-          $BOOST_PATH = "C:\local\boost_1_87_0"
-          if (Test-Path $BOOST_PATH) {
-          echo "Setting BOOST_ROOT..."
-          [System.Environment]::SetEnvironmentVariable("BOOST_ROOT", $BOOST_PATH, "Machine")
-          } else {
-          echo "ERROR: Boost directory not found at $BOOST_PATH"
-          }
+        #   # Set BOOST_ROOT manually
+        #   $BOOST_PATH = "C:\local\boost_1_87_0"
+        #   if (Test-Path $BOOST_PATH) {
+        #   echo "Setting BOOST_ROOT..."
+        #   [System.Environment]::SetEnvironmentVariable("BOOST_ROOT", $BOOST_PATH, "Machine")
+        #   } else {
+        #   echo "ERROR: Boost directory not found at $BOOST_PATH"
+        #   }
 
       - name: Build wheels
         run: |

--- a/.github/workflows/pypi-build.yml
+++ b/.github/workflows/pypi-build.yml
@@ -141,6 +141,11 @@ jobs:
             export LDFLAGS="-L$(brew --prefix boost)/lib"
           CIBW_BEFORE_ALL_WINDOWS: |
             choco install -y swig boost-msvc-14.2
+            # debugging steps. 
+            echo "Checking Boost environment variables..."
+            echo "BOOST_ROOT: $env:BOOST_ROOT"
+            echo "Checking Boost files..."
+            Get-ChildItem -Path C:\local\boost_1_82_0 -Recurse | Select-String "boost"
 
       - name: Upload artifacts for inspection
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pypi-build.yml
+++ b/.github/workflows/pypi-build.yml
@@ -167,6 +167,22 @@ jobs:
             echo "ERROR: Boost directory not found at $BOOST_PATH"
             }
 
+            # Set up MSVC environment variables
+            Import-Module "$env:ProgramFiles\Microsoft Visual Studio\Installer\vswhere"
+            $VCVarsPath = (& "$env:ProgramFiles\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath) + "\VC\Auxiliary\Build\vcvarsall.bat"
+            echo "Running vcvarsall.bat..."
+            cmd /c """$VCVarsPath"" x64 && set" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+            # Set BOOST_ROOT manually
+            echo "Setting BOOST_ROOT to C:\local\boost_1_87_0"
+            echo "BOOST_ROOT=C:\local\boost_1_87_0" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+            # Debug environment
+            echo "Checking BOOST_ROOT..."
+            echo "BOOST_ROOT: $env:BOOST_ROOT"
+            echo "Checking Boost library files..."
+            Get-ChildItem -Path C:\local\boost_1_87_0\lib64-msvc-14.2 -Filter "boost_*.lib"
+
       - name: Upload artifacts for inspection
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/pypi-build.yml
+++ b/.github/workflows/pypi-build.yml
@@ -107,6 +107,10 @@ jobs:
           CIBW_BEFORE_ALL_LINUX: |
             yum install -y wget python-devel pcre-devel
             yum install -y boost-devel boost-system boost-filesystem boost-thread boost-program-options swig
+            # Explicitly export Boost include and library paths
+            export CXXFLAGS="-I/usr/include/boost"
+            export LDFLAGS="-L/usr/lib64 -L/usr/lib"
+          CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=14.0
           CIBW_BEFORE_ALL_MACOS: |
             brew install boost swig
             export CXXFLAGS="-I$(brew --prefix boost)/include"

--- a/.github/workflows/pypi-build.yml
+++ b/.github/workflows/pypi-build.yml
@@ -93,6 +93,18 @@ jobs:
         run: |
           choco install -y swig boost-msvc-14.2
           echo "Boost and SWIG installed"
+
+          ls "C:\local\"
+
+          # Set BOOST_ROOT manually
+          $BOOST_PATH = "C:\local\boost_1_82_0"
+          if (Test-Path $BOOST_PATH) {
+          echo "Setting BOOST_ROOT..."
+          [System.Environment]::SetEnvironmentVariable("BOOST_ROOT", $BOOST_PATH, "Machine")
+          } else {
+          echo "ERROR: Boost directory not found at $BOOST_PATH"
+  }
+
           echo "Checking Boost environment variables..."
           echo "BOOST_ROOT: $env:BOOST_ROOT"
           echo "Checking Boost files..."

--- a/.github/workflows/pypi-build.yml
+++ b/.github/workflows/pypi-build.yml
@@ -36,7 +36,7 @@ jobs:
           - os: macos-latest
             arch: arm64
           - os: windows-latest
-            arch: x86_64
+            arch: AMD64
 
     steps:
       - name: Checkout
@@ -105,11 +105,35 @@ jobs:
 
           # Install dependencies inside cibuildwheel
           CIBW_BEFORE_ALL_LINUX: |
+            sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo 
+            sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo 
+            sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+            yum clean all && yum -y update 
             yum install -y wget python-devel pcre-devel
-            yum install -y boost-devel boost-system boost-filesystem boost-thread boost-program-options swig
-            # Explicitly export Boost include and library paths
-            export CXXFLAGS="-I/usr/include/boost"
-            export LDFLAGS="-L/usr/lib64 -L/usr/lib"
+
+            # Install SWIG
+            wget https://downloads.sourceforge.net/swig/swig-4.0.2.tar.gz
+            tar -xvf swig-4*.tar.gz 
+            cd swig-4*
+            ./configure --prefix=/usr --without-maximum-compile-warnings && make
+            make install && install -v -m755 -d /usr/share/doc/swig-4.0.2 && cp -v -R Doc/* /usr/share/doc/swig-4.0.2
+            cd ..
+
+            # Install Boost
+            # wget https://boostorg.jfrog.io/artifactory/main/release/1.75.0/source/boost_1_75_0.tar.gz
+            wget https://archives.boost.io/release/1.82.0/source/boost_1_82_0.tar.gz
+            tar -xzf boost_1_82_0.tar.gz
+            cd boost_1_82_0 
+            ls
+            ./bootstrap.sh --prefix=/usr --with-python=python
+            ./b2 install threading=multi link=shared
+            cd ..
+            export CXXFLAGS="-I/usr/include"
+            export LDFLAGS="-L/usr/lib64"
+
+            # Clean up
+            rm -rf boost_1_*
+            rm -rf swig-4*
           CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=14.0
           CIBW_BEFORE_ALL_MACOS: |
             brew install boost swig

--- a/.github/workflows/pypi-build.yml
+++ b/.github/workflows/pypi-build.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - develop
+      - pip-win-macos
     paths-ignore:
       - 'example/**'
       - 'docs/**'
@@ -23,12 +24,18 @@ on:
 
 jobs:
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}
+    name: Build wheels on ${{ matrix.os }} / ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         include:
           - os: ubuntu-latest
+            arch: x86_64
+          - os: macos-latest
+            arch: x86_64
+          - os: macos-latest
+            arch: arm64
+          - os: windows-latest
             arch: x86_64
 
     steps:
@@ -45,7 +52,7 @@ jobs:
         if: runner.os == 'Linux'
         uses: docker/setup-qemu-action@v2
         with:
-          platforms: arm64
+          platforms: arm64 
       - name: Add tag to version.py file
         run: |
           git describe --abbrev=7 --dirty --always --tags | \
@@ -60,6 +67,21 @@ jobs:
         run: |
           echo "checking setuptools version"
           python -c "import setuptools; print(setuptools.__version__)"
+
+      # - name: Install dependencies (Linux)
+      #   if: runner.os == 'Linux'
+      #   run: |
+      #     sudo apt-get update
+      #     sudo apt-get install -y libboost-all-dev swig
+      # - name: Install dependencies (macOS)
+      #   if: runner.os == 'macOS'
+      #   run: |
+      #     brew install boost swig
+      # - name: Install dependencies (Windows)
+      #   if: runner.os == 'Windows'
+      #   run: |
+      #     choco install -y swig boost-msvc-14.2
+      #     echo "Boost and SWIG installed"
       - name: Build wheels
         run: |
           cp -R ./build/python/* .
@@ -67,43 +89,18 @@ jobs:
         env:
           CIBW_BUILD: cp38-* cp39-* cp310-* cp311-* cp312-*
           CIBW_SKIP: pp*
-          CIBW_ARCHS: auto64
-          CIBW_ARCHS_LINUX: ${{ matrix.arch }}
-          CIBW_BEFORE_BUILD: |
-            pip install --upgrade pip setuptools wheel packaging
+          
+          CIBW_ARCHS: ${{ matrix.arch }}
+
+          # Install dependencies inside cibuildwheel
+          CIBW_BEFORE_ALL_LINUX: |
+            yum install -y wget python-devel pcre-devel
+            yum install -y boost-devel swig  # Ensure Boost and SWIG inside manylinux
           CIBW_BEFORE_ALL_MACOS: |
             brew install boost swig
-          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-          CIBW_BEFORE_ALL_LINUX: |
-            sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo 
-            sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo 
-            sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
-            yum clean all && yum -y update 
-            yum install -y wget python-devel pcre-devel
-
-            # Install SWIG
-            wget https://downloads.sourceforge.net/swig/swig-4.0.2.tar.gz
-            tar -xvf swig-4*.tar.gz 
-            cd swig-4*
-            ./configure --prefix=/usr --without-maximum-compile-warnings && make
-            make install && install -v -m755 -d /usr/share/doc/swig-4.0.2 && cp -v -R Doc/* /usr/share/doc/swig-4.0.2
-            cd ..
-
-            # Install Boost
-            # wget https://boostorg.jfrog.io/artifactory/main/release/1.75.0/source/boost_1_75_0.tar.gz
-            wget https://archives.boost.io/release/1.82.0/source/boost_1_82_0.tar.gz
-            tar -xzf boost_1_82_0.tar.gz
-            cd boost_1_82_0 
-            ls
-            ./bootstrap.sh --prefix=/usr --with-python=python
-            ./b2 install threading=multi link=shared
-            cd ..
-            export CXXFLAGS="-I/usr/include"
-            export LDFLAGS="-L/usr/lib64"
-
-            # Clean up
-            rm -rf boost_1_*
-            rm -rf swig-4*
+          CIBW_BEFORE_ALL_WINDOWS: |
+            choco install -y swig boost-msvc-14.2
+            
       - name: Upload artifacts for inspection
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/pypi-build.yml
+++ b/.github/workflows/pypi-build.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
       - develop
-      - pip-win-macos
     paths-ignore:
       - 'example/**'
       - 'docs/**'
@@ -86,23 +85,6 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           brew install boost swig
-      # - name: Install dependencies (Windows)
-      #   if: runner.os == 'Windows'
-      #   run: |
-      #     choco install -y swig boost-msvc-14.2
-      #     echo "Boost and SWIG installed"
-
-      #     ls "C:\local\"
-
-      #     # Set BOOST_ROOT manually
-      #     $BOOST_PATH = "C:\local\boost_1_87_0"
-      #     if (Test-Path $BOOST_PATH) {
-      #     echo "Setting BOOST_ROOT..."
-      #     [System.Environment]::SetEnvironmentVariable("BOOST_ROOT", $BOOST_PATH, "Machine")
-      #     } else {
-      #     echo "ERROR: Boost directory not found at $BOOST_PATH"
-      #     }
-
       - name: Build wheels
         run: |
           cp -R ./build/python/* .

--- a/.github/workflows/pypi-build.yml
+++ b/.github/workflows/pypi-build.yml
@@ -35,8 +35,6 @@ jobs:
             arch: x86_64
           - os: macos-latest
             arch: arm64
-          - os: windows-latest
-            arch: AMD64
 
     steps:
       - name: Checkout
@@ -151,37 +149,6 @@ jobs:
             brew install boost swig
             export CXXFLAGS="-I$(brew --prefix boost)/include"
             export LDFLAGS="-L$(brew --prefix boost)/lib"
-          CIBW_BEFORE_ALL_WINDOWS: |
-            choco install -y swig boost-msvc-14.2
-            # debugging steps. 
-            echo "Boost and SWIG installed"
-
-            ls "C:\local\"
-  
-            # Set BOOST_ROOT manually
-            $BOOST_PATH = "C:\local\boost_1_87_0"
-            if (Test-Path $BOOST_PATH) {
-            echo "Setting BOOST_ROOT..."
-            [System.Environment]::SetEnvironmentVariable("BOOST_ROOT", $BOOST_PATH, "Machine")
-            } else {
-            echo "ERROR: Boost directory not found at $BOOST_PATH"
-            }
-
-            # Set up MSVC environment variables
-            Import-Module "$env:ProgramFiles\Microsoft Visual Studio\Installer\vswhere"
-            $VCVarsPath = (& "$env:ProgramFiles\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath) + "\VC\Auxiliary\Build\vcvarsall.bat"
-            echo "Running vcvarsall.bat..."
-            cmd /c """$VCVarsPath"" x64 && set" | Out-File -FilePath $env:GITHUB_ENV -Append
-
-            # Set BOOST_ROOT manually
-            echo "Setting BOOST_ROOT to C:\local\boost_1_87_0"
-            echo "BOOST_ROOT=C:\local\boost_1_87_0" | Out-File -FilePath $env:GITHUB_ENV -Append
-
-            # Debug environment
-            echo "Checking BOOST_ROOT..."
-            echo "BOOST_ROOT: $env:BOOST_ROOT"
-            echo "Checking Boost library files..."
-            Get-ChildItem -Path C:\local\boost_1_87_0\lib64-msvc-14.2 -Filter "boost_*.lib"
 
       - name: Upload artifacts for inspection
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pypi-build.yml
+++ b/.github/workflows/pypi-build.yml
@@ -105,10 +105,6 @@ jobs:
           echo "ERROR: Boost directory not found at $BOOST_PATH"
           }
 
-          echo "Checking Boost environment variables..."
-          echo "BOOST_ROOT: $env:BOOST_ROOT"
-          echo "Checking Boost files..."
-          Get-ChildItem -Path C:\local\boost_1_87_0 -Recurse | Select-String "boost"
       - name: Build wheels
         run: |
           cp -R ./build/python/* .
@@ -158,10 +154,18 @@ jobs:
           CIBW_BEFORE_ALL_WINDOWS: |
             choco install -y swig boost-msvc-14.2
             # debugging steps. 
-            echo "Checking Boost environment variables..."
-            echo "BOOST_ROOT: $env:BOOST_ROOT"
-            echo "Checking Boost files..."
-            Get-ChildItem -Path C:\local\boost_1_82_0 -Recurse | Select-String "boost"
+            echo "Boost and SWIG installed"
+
+            ls "C:\local\"
+  
+            # Set BOOST_ROOT manually
+            $BOOST_PATH = "C:\local\boost_1_87_0"
+            if (Test-Path $BOOST_PATH) {
+            echo "Setting BOOST_ROOT..."
+            [System.Environment]::SetEnvironmentVariable("BOOST_ROOT", $BOOST_PATH, "Machine")
+            } else {
+            echo "ERROR: Boost directory not found at $BOOST_PATH"
+            }
 
       - name: Upload artifacts for inspection
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pypi-build.yml
+++ b/.github/workflows/pypi-build.yml
@@ -103,7 +103,7 @@ jobs:
           [System.Environment]::SetEnvironmentVariable("BOOST_ROOT", $BOOST_PATH, "Machine")
           } else {
           echo "ERROR: Boost directory not found at $BOOST_PATH"
-  }
+          }
 
           echo "Checking Boost environment variables..."
           echo "BOOST_ROOT: $env:BOOST_ROOT"

--- a/.github/workflows/pypi-build.yml
+++ b/.github/workflows/pypi-build.yml
@@ -88,22 +88,22 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           brew install boost swig
-      - name: Install dependencies (Windows)
-        # if: runner.os == 'Windows'
-        # run: |
-        #   choco install -y swig boost-msvc-14.2
-        #   echo "Boost and SWIG installed"
+      # - name: Install dependencies (Windows)
+      #   if: runner.os == 'Windows'
+      #   run: |
+      #     choco install -y swig boost-msvc-14.2
+      #     echo "Boost and SWIG installed"
 
-        #   ls "C:\local\"
+      #     ls "C:\local\"
 
-        #   # Set BOOST_ROOT manually
-        #   $BOOST_PATH = "C:\local\boost_1_87_0"
-        #   if (Test-Path $BOOST_PATH) {
-        #   echo "Setting BOOST_ROOT..."
-        #   [System.Environment]::SetEnvironmentVariable("BOOST_ROOT", $BOOST_PATH, "Machine")
-        #   } else {
-        #   echo "ERROR: Boost directory not found at $BOOST_PATH"
-        #   }
+      #     # Set BOOST_ROOT manually
+      #     $BOOST_PATH = "C:\local\boost_1_87_0"
+      #     if (Test-Path $BOOST_PATH) {
+      #     echo "Setting BOOST_ROOT..."
+      #     [System.Environment]::SetEnvironmentVariable("BOOST_ROOT", $BOOST_PATH, "Machine")
+      #     } else {
+      #     echo "ERROR: Boost directory not found at $BOOST_PATH"
+      #     }
 
       - name: Build wheels
         run: |

--- a/.github/workflows/pypi-build.yml
+++ b/.github/workflows/pypi-build.yml
@@ -93,6 +93,10 @@ jobs:
         run: |
           choco install -y swig boost-msvc-14.2
           echo "Boost and SWIG installed"
+          echo "Checking Boost environment variables..."
+          echo "BOOST_ROOT: $env:BOOST_ROOT"
+          echo "Checking Boost files..."
+          Get-ChildItem -Path C:\local\boost_1_82_0 -Recurse | Select-String "boost"
       - name: Build wheels
         run: |
           cp -R ./build/python/* .

--- a/.github/workflows/pypi-build.yml
+++ b/.github/workflows/pypi-build.yml
@@ -97,7 +97,7 @@ jobs:
           ls "C:\local\"
 
           # Set BOOST_ROOT manually
-          $BOOST_PATH = "C:\local\boost_1_82_0"
+          $BOOST_PATH = "C:\local\boost_1_87_0"
           if (Test-Path $BOOST_PATH) {
           echo "Setting BOOST_ROOT..."
           [System.Environment]::SetEnvironmentVariable("BOOST_ROOT", $BOOST_PATH, "Machine")
@@ -108,7 +108,7 @@ jobs:
           echo "Checking Boost environment variables..."
           echo "BOOST_ROOT: $env:BOOST_ROOT"
           echo "Checking Boost files..."
-          Get-ChildItem -Path C:\local\boost_1_82_0 -Recurse | Select-String "boost"
+          Get-ChildItem -Path C:\local\boost_1_87_0 -Recurse | Select-String "boost"
       - name: Build wheels
         run: |
           cp -R ./build/python/* .

--- a/.github/workflows/pypi-build.yml
+++ b/.github/workflows/pypi-build.yml
@@ -53,22 +53,25 @@ jobs:
         uses: docker/setup-qemu-action@v2
         with:
           platforms: arm64 
-      - name: Add tag to version.py file
+      - name: Add tag to version.py file windows
+        if: runner.os == 'windows'
+        shell: powershell
         run: |
-          if [[ "$RUNNER_OS" == "Windows" ]]; then
-            $version = git describe --abbrev=7 --dirty --always --tags
-            $version = $version -replace "dirty", "mod"
-            $version = $version -replace "-", "+"
-            $version = $version -replace "-", "."
-            $version = $version -replace "v", ""
-            Set-Content -Path .\build\python\vina\version.py -Value $version
-          else: 
-            git describe --abbrev=7 --dirty --always --tags | \
-              sed 's/dirty/mod/g' | \
-              sed 's/-/+/' | \
-              sed 's/-/./g' | \
-              sed 's/v//' > ./build/python/vina/version.py
-            cat ./build/python/vina/version.py
+          $version = git describe --abbrev=7 --dirty --always --tags
+          $version = $version -replace "dirty", "mod"
+          $version = $version -replace "-", "+"
+          $version = $version -replace "-", "."
+          $version = $version -replace "v", ""
+          Set-Content -Path .\build\python\vina\version.py -Value $version
+      - name: Add tag to version.py file linux and macos
+        if: runner.os != 'windows'
+        run: |  
+          git describe --abbrev=7 --dirty --always --tags | \
+            sed 's/dirty/mod/g' | \
+            sed 's/-/+/' | \
+            sed 's/-/./g' | \
+            sed 's/v//' > ./build/python/vina/version.py
+          cat ./build/python/vina/version.py
       - name: Install Python dependencies
         run: python -m pip install cibuildwheel setuptools wheel packaging
       - name: Check setuptools version
@@ -76,20 +79,20 @@ jobs:
           echo "checking setuptools version"
           python -c "import setuptools; print(setuptools.__version__)"
 
-      # - name: Install dependencies (Linux)
-      #   if: runner.os == 'Linux'
-      #   run: |
-      #     sudo apt-get update
-      #     sudo apt-get install -y libboost-all-dev swig
-      # - name: Install dependencies (macOS)
-      #   if: runner.os == 'macOS'
-      #   run: |
-      #     brew install boost swig
-      # - name: Install dependencies (Windows)
-      #   if: runner.os == 'Windows'
-      #   run: |
-      #     choco install -y swig boost-msvc-14.2
-      #     echo "Boost and SWIG installed"
+      - name: Install dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libboost-all-dev swig
+      - name: Install dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          brew install boost swig
+      - name: Install dependencies (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          choco install -y swig boost-msvc-14.2
+          echo "Boost and SWIG installed"
       - name: Build wheels
         run: |
           cp -R ./build/python/* .
@@ -106,6 +109,8 @@ jobs:
             yum install -y boost-devel swig  # Ensure Boost and SWIG inside manylinux
           CIBW_BEFORE_ALL_MACOS: |
             brew install boost swig
+            export CXXFLAGS="-I$(brew --prefix boost)/include"
+            export LDFLAGS="-L$(brew --prefix boost)/lib"
           CIBW_BEFORE_ALL_WINDOWS: |
             choco install -y swig boost-msvc-14.2
 

--- a/.github/workflows/pypi-build.yml
+++ b/.github/workflows/pypi-build.yml
@@ -106,7 +106,7 @@ jobs:
           # Install dependencies inside cibuildwheel
           CIBW_BEFORE_ALL_LINUX: |
             yum install -y wget python-devel pcre-devel
-            yum install -y boost-devel swig  # Ensure Boost and SWIG inside manylinux
+            yum install -y boost-devel boost-system boost-filesystem boost-thread boost-program-options swig
           CIBW_BEFORE_ALL_MACOS: |
             brew install boost swig
             export CXXFLAGS="-I$(brew --prefix boost)/include"

--- a/build/python/setup.py
+++ b/build/python/setup.py
@@ -151,35 +151,6 @@ def locate_boost():
                     print(f"Boost found in {path}")
                     return include_dirs, lib_dir
 
-
-   # Check Windows Paths
-    if sys.platform == "win32":
-        # 🔹 Check BOOST_ROOT environment variable
-        boost_root = os.environ.get("BOOST_ROOT", "")
-        if boost_root and os.path.isdir(os.path.join(boost_root, "boost")):
-            include_dirs = os.path.join(boost_root, "boost")
-            lib_dirs = os.path.join(boost_root, "lib64-msvc-14.2")
-
-            if glob.glob(f"{lib_dirs}\\boost_*.lib"):
-                print(f"Boost found at {boost_root}")
-                return include_dirs, lib_dirs
-
-        # 🔹 Check common Windows install paths
-        possible_paths = [
-            "C:\\local\\boost_1_87_0",  # Common manual install path
-            "C:\\Boost\\include",  # Alternative location
-            "C:\\Program Files\\Boost",  # Rare, but possible
-        ]
-
-        for path in possible_paths:
-            print(f"Checking path: {path}")
-            if os.path.isdir(os.path.join(path, "boost")):
-                include_dirs = os.path.join(path, "boost")
-                lib_dirs = os.path.join(path, "lib64-msvc-14.2")  # Update for MSVC
-
-                if glob.glob(f"{lib_dirs}\\boost_*.lib"):
-                    print(f"Boost found in {path}")
-                    return include_dirs, lib_dirs
                 
     include_dirs = '/usr/local/include'
 

--- a/build/python/setup.py
+++ b/build/python/setup.py
@@ -154,26 +154,33 @@ def locate_boost():
 
    # Check Windows Paths
     if sys.platform == "win32":
+        # 🔹 Check BOOST_ROOT environment variable
+        boost_root = os.environ.get("BOOST_ROOT", "")
+        if boost_root and os.path.isdir(os.path.join(boost_root, "boost")):
+            include_dirs = os.path.join(boost_root, "boost")
+            lib_dirs = os.path.join(boost_root, "lib64-msvc-14.2")
+
+            if glob.glob(f"{lib_dirs}\\boost_*.lib"):
+                print(f"Boost found at {boost_root}")
+                return include_dirs, lib_dirs
+
+        # 🔹 Check common Windows install paths
         possible_paths = [
-            "C:\\local\\boost_1_87_0",    # Common manual install path
-            "C:\\Boost\\include",         # Another common location
-            "C:\\Program Files\\Boost",   # Rare, but possible
-            os.environ.get("BOOST_ROOT", ""),  # Environment variable if set
+            "C:\\local\\boost_1_87_0",  # Common manual install path
+            "C:\\Boost\\include",  # Alternative location
+            "C:\\Program Files\\Boost",  # Rare, but possible
         ]
-        print ("debugging, possible paths:")
-        print(possible_paths)
-        print(os.listdir("C:\\local"))
-        print(os.listdir("C:\\local\\boost_1_87_0"))
+
         for path in possible_paths:
-            print(f"path: {path}")
-            if path and os.path.isdir(os.path.join(path, "include", "boost")):
-                include_dirs = os.path.join(path, "include")
-                lib_dirs = os.path.join(path, "lib")
+            print(f"Checking path: {path}")
+            if os.path.isdir(os.path.join(path, "boost")):
+                include_dirs = os.path.join(path, "boost")
+                lib_dirs = os.path.join(path, "lib64-msvc-14.2")  # Update for MSVC
 
                 if glob.glob(f"{lib_dirs}\\boost_*.lib"):
                     print(f"Boost found in {path}")
-                    return include_dirs, lib_dirs          
-                                
+                    return include_dirs, lib_dirs
+                
     include_dirs = '/usr/local/include'
 
     if os.path.isdir(include_dirs + os.path.sep + 'boost'):

--- a/build/python/setup.py
+++ b/build/python/setup.py
@@ -160,8 +160,12 @@ def locate_boost():
             "C:\\Program Files\\Boost",   # Rare, but possible
             os.environ.get("BOOST_ROOT", ""),  # Environment variable if set
         ]
-
+        print ("debugging, possible paths:")
+        print(possible_paths)
+        print(os.listdir("C:\\local"))
+        print(os.listdir("C:\\local\\boost_1_87_0"))
         for path in possible_paths:
+            print(f"path: {path}")
             if path and os.path.isdir(os.path.join(path, "include", "boost")):
                 include_dirs = os.path.join(path, "include")
                 lib_dirs = os.path.join(path, "lib")

--- a/build/python/setup.py
+++ b/build/python/setup.py
@@ -155,7 +155,7 @@ def locate_boost():
    # Check Windows Paths
     if sys.platform == "win32":
         possible_paths = [
-            "C:\\local\\boost_1_82_0",    # Common manual install path
+            "C:\\local\\boost_1_87_0",    # Common manual install path
             "C:\\Boost\\include",         # Another common location
             "C:\\Program Files\\Boost",   # Rare, but possible
             os.environ.get("BOOST_ROOT", ""),  # Environment variable if set

--- a/build/python/setup.py
+++ b/build/python/setup.py
@@ -127,6 +127,7 @@ def locate_boost():
             print('Boost library is not installed in this conda environment.')
 
 
+    # macos paths
     macos_paths = ["/opt/homebrew", "/usr/local"]
     for path in macos_paths:
         include_dirs = f"{path}/include"
@@ -138,7 +139,7 @@ def locate_boost():
                     print(f"Boost found in {path}")
                     return include_dirs, lib_dir
                 
-    # ✅ Standard Linux paths
+    # Standard Linux paths
     linux_paths = ["/usr/local", "/usr"]
     for path in linux_paths:
         include_dirs = f"{path}/include"
@@ -303,7 +304,7 @@ class CustomBuildExt(build_ext):
 
         # Source: https://stackoverflow.com/questions/9723793/undefined-reference-to-boostsystemsystem-category-when-compiling
         vina_compiler_options = [
-                               "-std=c++11",
+                               "-std=c++14",
                                "-Wno-long-long",
                                "-pedantic",
                                '-DBOOST_ERROR_CODE_HEADER_ONLY'

--- a/build/python/setup.py
+++ b/build/python/setup.py
@@ -151,7 +151,25 @@ def locate_boost():
                     print(f"Boost found in {path}")
                     return include_dirs, lib_dir
 
-                          
+
+   # Check Windows Paths
+    if sys.platform == "win32":
+        possible_paths = [
+            "C:\\local\\boost_1_82_0",    # Common manual install path
+            "C:\\Boost\\include",         # Another common location
+            "C:\\Program Files\\Boost",   # Rare, but possible
+            os.environ.get("BOOST_ROOT", ""),  # Environment variable if set
+        ]
+
+        for path in possible_paths:
+            if path and os.path.isdir(os.path.join(path, "include", "boost")):
+                include_dirs = os.path.join(path, "include")
+                lib_dirs = os.path.join(path, "lib")
+
+                if glob.glob(f"{lib_dirs}\\boost_*.lib"):
+                    print(f"Boost found in {path}")
+                    return include_dirs, lib_dirs          
+                                
     include_dirs = '/usr/local/include'
 
     if os.path.isdir(include_dirs + os.path.sep + 'boost'):

--- a/build/python/setup.py
+++ b/build/python/setup.py
@@ -116,6 +116,7 @@ def locate_boost():
             data_pathname = os.environ["CONDA_PREFIX"]
         else:
             data_pathname = sysconfig.get_path("data") # just for readthedocs build
+
         include_dirs = data_pathname + os.path.sep + 'include'
         library_dirs = data_pathname + os.path.sep + 'lib'
 
@@ -125,6 +126,31 @@ def locate_boost():
         else:
             print('Boost library is not installed in this conda environment.')
 
+
+    macos_paths = ["/opt/homebrew", "/usr/local"]
+    for path in macos_paths:
+        include_dirs = f"{path}/include"
+        lib_dirs = [f"{path}/lib", f"{path}/lib64"]
+
+        if os.path.isdir(os.path.join(include_dirs, "boost")):
+            for lib_dir in lib_dirs:
+                if glob.glob(f"{lib_dir}/libboost*"):
+                    print(f"Boost found in {path}")
+                    return include_dirs, lib_dir
+                
+    # ✅ Standard Linux paths
+    linux_paths = ["/usr/local", "/usr"]
+    for path in linux_paths:
+        include_dirs = f"{path}/include"
+        lib_dirs = [f"{path}/lib", f"{path}/lib64", f"{path}/lib/x86_64-linux-gnu", f"{path}/lib/aarch64-linux-gnu"]
+
+        if os.path.isdir(os.path.join(include_dirs, "boost")):
+            for lib_dir in lib_dirs:
+                if glob.glob(f"{lib_dir}/libboost*"):
+                    print(f"Boost found in {path}")
+                    return include_dirs, lib_dir
+
+                          
     include_dirs = '/usr/local/include'
 
     if os.path.isdir(include_dirs + os.path.sep + 'boost'):


### PR DESCRIPTION
This PR ensures that wheels for the python binding are built and uploaded for the macos platform. Windows will take a backseat for now, people can just use the linux version on WSL. 