### PR TITLE
feat: Add runtime statistics option

### DIFF
--- a/src/lib/bfgs.h
+++ b/src/lib/bfgs.h
@@ -63,7 +63,7 @@ inline bool bfgs_update(flmat& h, const Change& p, const Change& y, const fl alp
 }
 
 template<typename F, typename Conf, typename Change>
-fl line_search(F& f, sz n, const Conf& x, const Change& g, const fl f0, const Change& p, Conf& x_new, Change& g_new, fl& f1, int& evalcount) { // returns alpha
+fl line_search(F& f, sz n, const Conf& x, const Change& g, const fl f0, const Change& p, Conf& x_new, Change& g_new, fl& f1, sz& evalcount) { // returns alpha
 	const fl c0 = 0.0001;
 	const unsigned max_trials = 10;
 	const fl multiplier = 0.5;
@@ -94,8 +94,7 @@ void subtract_change(Change& b, const Change& a, sz n) { // b -= a
 }
 
 template<typename F, typename Conf, typename Change>
-fl bfgs(F& f, Conf& x, Change& g, const unsigned max_steps, const fl average_required_improvement, const sz over,
-		int& evalcount) { // x is I/O, final value is returned
+fl bfgs(F& f, Conf& x, Change& g, const unsigned max_steps, const fl average_required_improvement, const sz over, sz& evalcount) { // x is I/O, final value is returned
 	sz n = g.num_floats();
 	flmat h(n, 0);
 	set_diagonal(h, 1);

--- a/src/lib/bfgs.h
+++ b/src/lib/bfgs.h
@@ -63,18 +63,19 @@ inline bool bfgs_update(flmat& h, const Change& p, const Change& y, const fl alp
 }
 
 template<typename F, typename Conf, typename Change>
-fl line_search(F& f, sz n, const Conf& x, const Change& g, const fl f0, const Change& p, Conf& x_new, Change& g_new, fl& f1, sz& evalcount) { // returns alpha
+fl line_search(F& f, sz n, const Conf& x, const Change& g, const fl f0, const Change& p, Conf& x_new, Change& g_new, fl& f1, stats& statcount) { // returns alpha
 	const fl c0 = 0.0001;
 	const unsigned max_trials = 10;
 	const fl multiplier = 0.5;
 	fl alpha = 1;
+	statcount[3]++; // increment line search counter
 
 	const fl pg = scalar_product(p, g, n);
 
 	VINA_U_FOR(trial, max_trials) {
 		x_new = x; x_new.increment(p, alpha);
 		f1 = f(x_new, g_new);
-		evalcount++;
+		statcount[0]++;
 		if(f1 - f0 < c0 * alpha * pg) // FIXME check - div by norm(p) ? no?
 			break;
 		alpha *= multiplier;
@@ -94,7 +95,7 @@ void subtract_change(Change& b, const Change& a, sz n) { // b -= a
 }
 
 template<typename F, typename Conf, typename Change>
-fl bfgs(F& f, Conf& x, Change& g, const unsigned max_steps, const fl average_required_improvement, const sz over, sz& evalcount) { // x is I/O, final value is returned
+fl bfgs(F& f, Conf& x, Change& g, const unsigned max_steps, const fl average_required_improvement, const sz over, stats& statcount) { // x is I/O, final value is returned
 	sz n = g.num_floats();
 	flmat h(n, 0);
 	set_diagonal(h, 1);
@@ -102,7 +103,7 @@ fl bfgs(F& f, Conf& x, Change& g, const unsigned max_steps, const fl average_req
 	Change g_new(g);
 	Conf x_new(x);
 	fl f0 = f(x, g);
-	evalcount++;
+	statcount[0]++;
 
 	fl f_orig = f0;
 	Change g_orig(g);
@@ -116,7 +117,7 @@ fl bfgs(F& f, Conf& x, Change& g, const unsigned max_steps, const fl average_req
 	VINA_U_FOR(step, max_steps) {
 		minus_mat_vec_product(h, g, p);
 		fl f1 = 0;
-		const fl alpha = line_search(f, n, x, g, f0, p, x_new, g_new, f1, evalcount);
+		const fl alpha = line_search(f, n, x, g, f0, p, x_new, g_new, f1, statcount);
 		Change y(g_new); subtract_change(y, g, n);
 
 		f_values.push_back(f1);

--- a/src/lib/common.h
+++ b/src/lib/common.h
@@ -54,6 +54,25 @@ const fl not_a_num = std::sqrt(fl(-1)); // FIXME? check
 typedef std::size_t sz;
 typedef std::pair<fl, fl> pr;
 
+struct stats {
+	sz data[4]; // 0 .. evalcount, 1 .. nr tries, 2 .. nr accepted, 3 .. nr line searches
+	stats() {
+		this->reset();
+	}
+	const sz& operator[](int i) const { assert(i < 4); return data[i]; }
+	      sz& operator[](int i)       { assert(i < 4); return data[i]; }
+	const stats& operator+=(const stats& v) {
+		data[0] += v[0];
+		data[1] += v[1];
+		data[2] += v[2];
+		data[3] += v[3];
+		return *this;
+	}
+	void reset() {
+		data[0] = data[1] = data[2] = data[3] = 0;
+	}
+};
+
 struct vec {
 	fl data[3];
 	vec() {

--- a/src/lib/conf.h
+++ b/src/lib/conf.h
@@ -362,9 +362,9 @@ struct output_type {
 	fl ub;
 	fl intra;
 	fl inter;
-    fl conf_independent;
-    fl unbound;
-    fl total;
+	fl conf_independent;
+	fl unbound;
+	fl total;
 	vecv coords;
 	output_type(const conf& c_, fl e_) : c(c_), e(e_) {}
 	//output_type(const conf& c_, fl e_, fl intra_, fl conf_independent_) : c(c_), e(e_), intra(intra_), conf_independent(conf_independent_) {}

--- a/src/lib/model.cpp
+++ b/src/lib/model.cpp
@@ -449,6 +449,7 @@ void model::assign_types() {
 			case EL_TYPE_SIZE : break;
 			default: VINA_CHECK(false);
 		}
+//		std::cout << ai.i+1 << ": " << x << "\n";
 	}
 }
 

--- a/src/lib/model.cpp
+++ b/src/lib/model.cpp
@@ -449,7 +449,6 @@ void model::assign_types() {
 			case EL_TYPE_SIZE : break;
 			default: VINA_CHECK(false);
 		}
-//		std::cout << ai.i+1 << ": " << x << "\n";
 	}
 }
 

--- a/src/lib/monte_carlo.cpp
+++ b/src/lib/monte_carlo.cpp
@@ -25,9 +25,9 @@
 #include "mutate.h"
 #include "quasi_newton.h"
 
-output_type monte_carlo::operator()(model& m, const precalculate_byatom& p, const igrid& ig, const vec& corner1, const vec& corner2, incrementable* increment_me, rng& generator, sz& evalcount) const {
+output_type monte_carlo::operator()(model& m, const precalculate_byatom& p, const igrid& ig, const vec& corner1, const vec& corner2, incrementable* increment_me, rng& generator, stats& statcount) const {
 	output_container tmp;
-	this->operator()(m, tmp, p, ig, corner1, corner2, increment_me, generator, evalcount); // call the version that produces the whole container
+	this->operator()(m, tmp, p, ig, corner1, corner2, increment_me, generator, statcount); // call the version that produces the whole container
 	VINA_CHECK(!tmp.empty());
 	return tmp.front();
 }
@@ -39,11 +39,11 @@ bool metropolis_accept(fl old_f, fl new_f, fl temperature, rng& generator) {
 }
 
 // out is sorted
-void monte_carlo::operator()(model& m, output_container& out, const precalculate_byatom& p, const igrid& ig, const vec& corner1, const vec& corner2, incrementable* increment_me, rng& generator, sz& evalcount) const {
+void monte_carlo::operator()(model& m, output_container& out, const precalculate_byatom& p, const igrid& ig, const vec& corner1, const vec& corner2, incrementable* increment_me, rng& generator, stats& statcount) const {
 	vec authentic_v(1000, 1000, 1000); // FIXME? this is here to avoid max_fl/max_fl
 	conf_size s = m.get_size();
 	change g(s);
-	sz e_count = 0;
+	stats l_count;
 	output_type tmp(s, 0);
 	tmp.c.randomize(corner1, corner2, generator);
 	fl best_e = max_fl;
@@ -52,17 +52,18 @@ void monte_carlo::operator()(model& m, output_container& out, const precalculate
 	VINA_U_FOR(step, global_steps) {
 		if(increment_me)
 			++(*increment_me);
-		if((max_evals > 0) & (e_count > max_evals))
+		if((max_evals > 0) & (l_count[0] > max_evals))
 			break;
 		output_type candidate = tmp;
+		l_count[1]++; // increase nr tries
 		mutate_conf(candidate.c, m, mutation_amplitude, generator);
-		quasi_newton_par(m, p, ig, candidate, g, hunt_cap, e_count);
+		quasi_newton_par(m, p, ig, candidate, g, hunt_cap, l_count);
 		if(step == 0 || metropolis_accept(tmp.e, candidate.e, temperature, generator)) {
 			tmp = candidate;
-
+			l_count[2]++; // increase nr accepted
 			// FIXME only for very promising ones
 			if(tmp.e < best_e || out.size() < num_saved_mins) {
-				quasi_newton_par(m, p, ig, tmp, g, authentic_v, e_count);
+				quasi_newton_par(m, p, ig, tmp, g, authentic_v, l_count);
 				tmp.coords = m.get_heavy_atom_movable_coords();
 				add_to_output_container(out, tmp, min_rmsd, num_saved_mins); // 20 - max size
 				if(tmp.e < best_e)
@@ -70,7 +71,7 @@ void monte_carlo::operator()(model& m, output_container& out, const precalculate
 			}
 		}
 	}
-	evalcount += e_count;
+	statcount += l_count;
 	VINA_CHECK(!out.empty());
 	VINA_CHECK(out.front().e <= out.back().e); // make sure the sorting worked in the correct order
 }

--- a/src/lib/monte_carlo.cpp
+++ b/src/lib/monte_carlo.cpp
@@ -25,9 +25,9 @@
 #include "mutate.h"
 #include "quasi_newton.h"
 
-output_type monte_carlo::operator()(model& m, const precalculate_byatom& p, const igrid& ig, const vec& corner1, const vec& corner2, incrementable* increment_me, rng& generator) const {
+output_type monte_carlo::operator()(model& m, const precalculate_byatom& p, const igrid& ig, const vec& corner1, const vec& corner2, incrementable* increment_me, rng& generator, sz& evalcount) const {
 	output_container tmp;
-	this->operator()(m, tmp, p, ig, corner1, corner2, increment_me, generator); // call the version that produces the whole container
+	this->operator()(m, tmp, p, ig, corner1, corner2, increment_me, generator, evalcount); // call the version that produces the whole container
 	VINA_CHECK(!tmp.empty());
 	return tmp.front();
 }
@@ -39,30 +39,30 @@ bool metropolis_accept(fl old_f, fl new_f, fl temperature, rng& generator) {
 }
 
 // out is sorted
-void monte_carlo::operator()(model& m, output_container& out, const precalculate_byatom& p, const igrid& ig, const vec& corner1, const vec& corner2, incrementable* increment_me, rng& generator) const {
-    int evalcount = 0;
+void monte_carlo::operator()(model& m, output_container& out, const precalculate_byatom& p, const igrid& ig, const vec& corner1, const vec& corner2, incrementable* increment_me, rng& generator, sz& evalcount) const {
 	vec authentic_v(1000, 1000, 1000); // FIXME? this is here to avoid max_fl/max_fl
 	conf_size s = m.get_size();
 	change g(s);
+	sz e_count = 0;
 	output_type tmp(s, 0);
 	tmp.c.randomize(corner1, corner2, generator);
 	fl best_e = max_fl;
 	quasi_newton quasi_newton_par;
-    quasi_newton_par.max_steps = local_steps;
+	quasi_newton_par.max_steps = local_steps;
 	VINA_U_FOR(step, global_steps) {
 		if(increment_me)
 			++(*increment_me);
-		if((max_evals > 0) & (evalcount > max_evals))
+		if((max_evals > 0) & (e_count > max_evals))
 			break;
 		output_type candidate = tmp;
 		mutate_conf(candidate.c, m, mutation_amplitude, generator);
-		quasi_newton_par(m, p, ig, candidate, g, hunt_cap, evalcount);
+		quasi_newton_par(m, p, ig, candidate, g, hunt_cap, e_count);
 		if(step == 0 || metropolis_accept(tmp.e, candidate.e, temperature, generator)) {
 			tmp = candidate;
 
 			// FIXME only for very promising ones
 			if(tmp.e < best_e || out.size() < num_saved_mins) {
-				quasi_newton_par(m, p, ig, tmp, g, authentic_v, evalcount);
+				quasi_newton_par(m, p, ig, tmp, g, authentic_v, e_count);
 				tmp.coords = m.get_heavy_atom_movable_coords();
 				add_to_output_container(out, tmp, min_rmsd, num_saved_mins); // 20 - max size
 				if(tmp.e < best_e)
@@ -70,6 +70,7 @@ void monte_carlo::operator()(model& m, output_container& out, const precalculate
 			}
 		}
 	}
+	evalcount += e_count;
 	VINA_CHECK(!out.empty());
 	VINA_CHECK(out.front().e <= out.back().e); // make sure the sorting worked in the correct order
 }

--- a/src/lib/monte_carlo.h
+++ b/src/lib/monte_carlo.h
@@ -39,10 +39,10 @@ struct monte_carlo {
 	monte_carlo() : max_evals(0), global_steps(2500), temperature(1.2), hunt_cap(10, 1.5, 10), min_rmsd(0.5), num_saved_mins(50), mutation_amplitude(2) {}
 
 	output_type operator()(model& m, const precalculate_byatom& p, const igrid& ig, const vec& corner1,
-                           const vec& corner2, incrementable* increment_me, rng& generator, sz& evalcount) const;
+                           const vec& corner2, incrementable* increment_me, rng& generator, stats& statcount) const;
 	// out is sorted
 	void operator()(model& m, output_container& out, const precalculate_byatom& p, const igrid& ig,
-	                const vec& corner1, const vec& corner2, incrementable* increment_me, rng& generator, sz& evalcount) const;
+	                const vec& corner1, const vec& corner2, incrementable* increment_me, rng& generator, stats& statcount) const;
 };
 
 #endif

--- a/src/lib/monte_carlo.h
+++ b/src/lib/monte_carlo.h
@@ -27,7 +27,7 @@
 #include "model.h"
 
 struct monte_carlo {
-    unsigned max_evals;
+	unsigned max_evals;
 	unsigned global_steps;
 	fl temperature;
 	vec hunt_cap;
@@ -35,14 +35,14 @@ struct monte_carlo {
 	sz num_saved_mins;
 	fl mutation_amplitude;
 	unsigned local_steps;
-    // T = 600K, R = 2cal/(K*mol) -> temperature = RT = 1.2;  global_steps = 50*lig_atoms = 2500
-    monte_carlo() : max_evals(0), global_steps(2500), temperature(1.2), hunt_cap(10, 1.5, 10), min_rmsd(0.5), num_saved_mins(50), mutation_amplitude(2) {}
+	// T = 600K, R = 2cal/(K*mol) -> temperature = RT = 1.2;  global_steps = 50*lig_atoms = 2500
+	monte_carlo() : max_evals(0), global_steps(2500), temperature(1.2), hunt_cap(10, 1.5, 10), min_rmsd(0.5), num_saved_mins(50), mutation_amplitude(2) {}
 
 	output_type operator()(model& m, const precalculate_byatom& p, const igrid& ig, const vec& corner1,
-                           const vec& corner2, incrementable* increment_me, rng& generator) const;
+                           const vec& corner2, incrementable* increment_me, rng& generator, sz& evalcount) const;
 	// out is sorted
 	void operator()(model& m, output_container& out, const precalculate_byatom& p, const igrid& ig,
-                    const vec& corner1, const vec& corner2, incrementable* increment_me, rng& generator) const;
+	                const vec& corner1, const vec& corner2, incrementable* increment_me, rng& generator, sz& evalcount) const;
 };
 
 #endif

--- a/src/lib/parallel.h
+++ b/src/lib/parallel.h
@@ -36,27 +36,29 @@
 template<typename F, bool Sync = false>
 struct parallel_for : private boost::thread_group {
 	parallel_for(const F* f, sz num_threads) : m_f(f), destructing(false), size(0), thread_finished(num_threads, true), count_finished(0), num_threads(num_threads) {
-        VINA_FOR(i, num_threads)
-            create_thread(aux(i, this));
-    }
+		VINA_FOR(i, num_threads)
+			create_thread(aux(i, this));
+	}
+
 	void run(sz size_) {
 		boost::mutex::scoped_lock self_lk(self);
-        size = size_;
-        count_finished = 0;
-		VINA_FOR_IN(i, thread_finished) 
+		size = size_;
+		count_finished = 0;
+		VINA_FOR_IN(i, thread_finished)
 			thread_finished[i] = false;
-        cond.notify_all(); // many things modified
-        while(count_finished < num_threads) // wait until processing of all elements is thread_finished
-            busy.wait(self_lk);
-    }
-    virtual ~parallel_for() {
-        {
+		cond.notify_all(); // many things modified
+		while(count_finished < num_threads) // wait until processing of all elements is thread_finished
+			busy.wait(self_lk);
+	}
+
+	virtual ~parallel_for() {
+		{
 			boost::mutex::scoped_lock self_lk(self);
-            destructing = true;
-            cond.notify_all(); // destructing modified
-        }
-        join_all(); 
-    }
+			destructing = true;
+			cond.notify_all(); // destructing modified
+		}
+		join_all(); 
+	}
 private:
 	void loop(sz offset) {
 		while(boost::optional<sz> sz_option = get_size(offset)) {
@@ -71,54 +73,60 @@ private:
 			}
 		}
 	}
-    struct aux {
+
+	struct aux {
 		sz offset;
-        parallel_for* par;
+		parallel_for* par;
 		aux(sz offset, parallel_for* par) : offset(offset), par(par) {}
 		void operator()() const { par->loop(offset); }
-    };
-    const F* m_f; // does not keep a local copy!
-    boost::condition cond;
-    boost::condition busy;
-    bool destructing; // dtor called
-    sz size; // size of the vector given to run()
+	};
+
+	const F* m_f; // does not keep a local copy!
+	boost::condition cond;
+	boost::condition busy;
+	bool destructing; // dtor called
+	sz size; // size of the vector given to run()
 	std::vector<bool> thread_finished;
-    sz count_finished; 
+	sz count_finished;
 	sz num_threads;
 	boost::mutex self; // any modification or reading of mutables should lock this first
+
 	boost::optional<sz> get_size(sz offset) {
 		boost::mutex::scoped_lock self_lk(self);
-        while(!destructing && thread_finished[offset])
-            cond.wait(self_lk);
+		while(!destructing && thread_finished[offset])
+			cond.wait(self_lk);
 		if(destructing) return boost::optional<sz>(); // wrap it up!
-        return size;
-    }
+		return size;
+	}
 };
 
 template<typename F>
 struct parallel_for<F, true> : private boost::thread_group {
 	parallel_for(const F* f, sz num_threads) : m_f(f), destructing(false), size(0), started(0), finished(0) {
 		a.par = this; // VC8 warning workaround
-        VINA_FOR(i, num_threads)
-            create_thread(boost::ref(a));
-    }
+		VINA_FOR(i, num_threads)
+			create_thread(boost::ref(a));
+	}
+
 	void run(sz size_) {
 		boost::mutex::scoped_lock self_lk(self);
-        size = size_;
-        finished = 0;
-        started = 0;
-        cond.notify_all(); // many things modified
-        while(finished < size) // wait until processing of all elements is finished
-            busy.wait(self_lk);
-    }
-    virtual ~parallel_for() {
-        {
+		size = size_;
+		finished = 0;
+		started = 0;
+		cond.notify_all(); // many things modified
+		while(finished < size) // wait until processing of all elements is finished
+			busy.wait(self_lk);
+	}
+
+	virtual ~parallel_for() {
+		{
 			boost::mutex::scoped_lock self_lk(self);
-            destructing = true;
-            cond.notify_all(); // destructing modified
-        }
-        join_all(); 
-    }
+			destructing = true;
+			cond.notify_all(); // destructing modified
+		}
+		join_all();
+	}
+
 private:
 	void loop() {
 		while(boost::optional<sz> i = get_next()) {
@@ -130,34 +138,34 @@ private:
 			}
 		}
 	}
-    struct aux {
-        parallel_for* par;
-        aux() : par(NULL) {}
+	struct aux {
+		parallel_for* par;
+		aux() : par(NULL) {}
 		void operator()() const { par->loop(); }
-    };
-    aux a;
-    const F* m_f; // does not keep a local copy!
-    boost::condition cond;
-    boost::condition busy;
-    bool destructing; // dtor called
-    sz size; // size of the vector given to run() // FIXME?
-    sz started; // the number of jobs given to run() the work started on
-    sz finished; // the number of jobs given to run() the work finished on
+	};
+	aux a;
+	const F* m_f; // does not keep a local copy!
+	boost::condition cond;
+	boost::condition busy;
+	bool destructing; // dtor called
+	sz size; // size of the vector given to run() // FIXME?
+	sz started; // the number of jobs given to run() the work started on
+	sz finished; // the number of jobs given to run() the work finished on
 	boost::mutex self; // any modification or reading of mutables should lock this first
 	boost::optional<sz> get_next() {
 		boost::mutex::scoped_lock self_lk(self);
-        while(!destructing && started >= size)
-            cond.wait(self_lk);
+		while(!destructing && started >= size)
+			cond.wait(self_lk);
 		if(destructing) return boost::optional<sz>(); // NOTHING
 		sz tmp = started;
-        ++started;
-        return tmp;
-    }
+		++started;
+		return tmp;
+	}
 };
 
 
 template<typename F, typename Container, typename Input, bool Sync = false>
-struct parallel_iter { 
+struct parallel_iter {
 	parallel_iter(const F* f, sz num_threads) : a(f), pf(&a, num_threads) {}
 	void run(Container& v) {
 		a.v = &v;

--- a/src/lib/parallel_mc.cpp
+++ b/src/lib/parallel_mc.cpp
@@ -29,7 +29,7 @@ struct parallel_mc_task {
 	model m;
 	output_container out;
 	rng generator;
-	sz evalcount = 0;
+	stats statcount;
 	parallel_mc_task(const model& m_, int seed) : m(m_), generator(static_cast<rng::result_type>(seed)) {}
 };
 
@@ -45,7 +45,7 @@ struct parallel_mc_aux {
 	parallel_mc_aux(const monte_carlo* mc_, const precalculate_byatom* p_, const igrid* ig_, const vec* corner1_, const vec* corner2_, parallel_progress* pg_)
 		: mc(mc_), p(p_), ig(ig_), corner1(corner1_), corner2(corner2_), pg(pg_) {}
 	void operator()(parallel_mc_task& t) const {
-		(*mc)(t.m, t.out, *p, *ig, *corner1, *corner2, pg, t.generator, t.evalcount);
+		(*mc)(t.m, t.out, *p, *ig, *corner1, *corner2, pg, t.generator, t.statcount);
 	}
 };
 
@@ -54,16 +54,16 @@ void merge_output_containers(const output_container& in, output_container& out, 
 		add_to_output_container(out, in[i], min_rmsd, max_size);
 }
 
-void merge_output_containers(const parallel_mc_task_container& many, output_container& out, fl min_rmsd, sz max_size, sz& evalcount) {
+void merge_output_containers(const parallel_mc_task_container& many, output_container& out, fl min_rmsd, sz max_size, stats& statcount) {
 	min_rmsd = 2; // FIXME? perhaps it's necessary to separate min_rmsd during search and during output?
 	VINA_FOR_IN(i, many){
 		merge_output_containers(many[i].out, out, min_rmsd, max_size);
-		evalcount += many[i].evalcount;
+		statcount += many[i].statcount;
 	}
 	out.sort();
 }
 
-void parallel_mc::operator()(const model& m, output_container& out, const precalculate_byatom& p, const igrid& ig, const vec& corner1, const vec& corner2, rng& generator, sz& evalcount, std::function<void(double)>* progress_callback) const {
+void parallel_mc::operator()(const model& m, output_container& out, const precalculate_byatom& p, const igrid& ig, const vec& corner1, const vec& corner2, rng& generator, stats& statcount, std::function<void(double)>* progress_callback) const {
 	parallel_progress pp (progress_callback);
 	parallel_mc_aux parallel_mc_aux_instance(&mc, &p, &ig, &corner1, &corner2, (display_progress ? (&pp) : NULL));
 	parallel_mc_task_container task_container;
@@ -73,5 +73,5 @@ void parallel_mc::operator()(const model& m, output_container& out, const precal
 		pp.init(num_tasks * mc.global_steps);
 	parallel_iter<parallel_mc_aux, parallel_mc_task_container, parallel_mc_task, true> parallel_iter_instance(&parallel_mc_aux_instance, num_threads);
 	parallel_iter_instance.run(task_container);
-	merge_output_containers(task_container, out, mc.min_rmsd, mc.num_saved_mins, evalcount);
+	merge_output_containers(task_container, out, mc.min_rmsd, mc.num_saved_mins, statcount);
 }

--- a/src/lib/parallel_mc.cpp
+++ b/src/lib/parallel_mc.cpp
@@ -29,6 +29,7 @@ struct parallel_mc_task {
 	model m;
 	output_container out;
 	rng generator;
+	sz evalcount = 0;
 	parallel_mc_task(const model& m_, int seed) : m(m_), generator(static_cast<rng::result_type>(seed)) {}
 };
 
@@ -44,7 +45,7 @@ struct parallel_mc_aux {
 	parallel_mc_aux(const monte_carlo* mc_, const precalculate_byatom* p_, const igrid* ig_, const vec* corner1_, const vec* corner2_, parallel_progress* pg_)
 		: mc(mc_), p(p_), ig(ig_), corner1(corner1_), corner2(corner2_), pg(pg_) {}
 	void operator()(parallel_mc_task& t) const {
-		(*mc)(t.m, t.out, *p, *ig, *corner1, *corner2, pg, t.generator);
+		(*mc)(t.m, t.out, *p, *ig, *corner1, *corner2, pg, t.generator, t.evalcount);
 	}
 };
 
@@ -53,22 +54,24 @@ void merge_output_containers(const output_container& in, output_container& out, 
 		add_to_output_container(out, in[i], min_rmsd, max_size);
 }
 
-void merge_output_containers(const parallel_mc_task_container& many, output_container& out, fl min_rmsd, sz max_size) {
+void merge_output_containers(const parallel_mc_task_container& many, output_container& out, fl min_rmsd, sz max_size, sz& evalcount) {
 	min_rmsd = 2; // FIXME? perhaps it's necessary to separate min_rmsd during search and during output?
-	VINA_FOR_IN(i, many)
+	VINA_FOR_IN(i, many){
 		merge_output_containers(many[i].out, out, min_rmsd, max_size);
+		evalcount += many[i].evalcount;
+	}
 	out.sort();
 }
 
-void parallel_mc::operator()(const model& m, output_container& out, const precalculate_byatom& p, const igrid& ig, const vec& corner1, const vec& corner2, rng& generator, std::function<void(double)>* progress_callback) const {
+void parallel_mc::operator()(const model& m, output_container& out, const precalculate_byatom& p, const igrid& ig, const vec& corner1, const vec& corner2, rng& generator, sz& evalcount, std::function<void(double)>* progress_callback) const {
 	parallel_progress pp (progress_callback);
 	parallel_mc_aux parallel_mc_aux_instance(&mc, &p, &ig, &corner1, &corner2, (display_progress ? (&pp) : NULL));
 	parallel_mc_task_container task_container;
 	VINA_FOR(i, num_tasks)
 		task_container.push_back(new parallel_mc_task(m, random_int(0, 1000000, generator)));
-	if(display_progress) 
+	if(display_progress)
 		pp.init(num_tasks * mc.global_steps);
 	parallel_iter<parallel_mc_aux, parallel_mc_task_container, parallel_mc_task, true> parallel_iter_instance(&parallel_mc_aux_instance, num_threads);
 	parallel_iter_instance.run(task_container);
-	merge_output_containers(task_container, out, mc.min_rmsd, mc.num_saved_mins);
+	merge_output_containers(task_container, out, mc.min_rmsd, mc.num_saved_mins, evalcount);
 }

--- a/src/lib/parallel_mc.h
+++ b/src/lib/parallel_mc.h
@@ -31,7 +31,7 @@ struct parallel_mc {
 	sz num_threads;
 	bool display_progress;
 	parallel_mc() : num_tasks(8), num_threads(1), display_progress(true) {}
-	void operator()(const model& m, output_container& out, const precalculate_byatom& p, const igrid& ig, const vec& corner1, const vec& corner2, rng& generator, sz& evalcount, std::function<void(double)>* progress_callback) const;
+	void operator()(const model& m, output_container& out, const precalculate_byatom& p, const igrid& ig, const vec& corner1, const vec& corner2, rng& generator, stats& statcount, std::function<void(double)>* progress_callback) const;
 };
 
 #endif

--- a/src/lib/parallel_mc.h
+++ b/src/lib/parallel_mc.h
@@ -31,7 +31,7 @@ struct parallel_mc {
 	sz num_threads;
 	bool display_progress;
 	parallel_mc() : num_tasks(8), num_threads(1), display_progress(true) {}
-	void operator()(const model& m, output_container& out, const precalculate_byatom& p, const igrid& ig, const vec& corner1, const vec& corner2, rng& generator, std::function<void(double)>* progress_callback) const;
+	void operator()(const model& m, output_container& out, const precalculate_byatom& p, const igrid& ig, const vec& corner1, const vec& corner2, rng& generator, sz& evalcount, std::function<void(double)>* progress_callback) const;
 };
 
 #endif

--- a/src/lib/precalculate.h
+++ b/src/lib/precalculate.h
@@ -141,7 +141,7 @@ public:
 
         VINA_FOR(t1, data.dim())
         {
-            VINA_RANGE(t2, t1, data.dim())
+            VINA_RANGE(t2, t1, data.dim()) // t1 < t2
             {
                 precalculate_element &p = data(t1, t2);
                 // init smooth[].first

--- a/src/lib/quasi_newton.cpp
+++ b/src/lib/quasi_newton.cpp
@@ -31,7 +31,7 @@ struct quasi_newton_aux {
     const vec v;
 
     quasi_newton_aux(model* m_, const precalculate_byatom* p_, const igrid* ig_, const vec& v_) : m(m_), p(p_), ig(ig_), v(v_) {}
-    
+
     fl operator()(const conf& c, change& g) {
         // Before evaluating conf, we have to update model
         m->set(c);
@@ -40,7 +40,7 @@ struct quasi_newton_aux {
     }
 };
 
-void quasi_newton::operator()(model& m, const precalculate_byatom& p, const igrid& ig, output_type& out, change& g, const vec& v, int& evalcount) const { // g must have correct size
+void quasi_newton::operator()(model& m, const precalculate_byatom& p, const igrid& ig, output_type& out, change& g, const vec& v, sz& evalcount) const { // g must have correct size
     quasi_newton_aux aux(&m, &p, &ig, v);
 
     fl res = bfgs(aux, out.c, g, max_steps, average_required_improvement, 10, evalcount);

--- a/src/lib/quasi_newton.cpp
+++ b/src/lib/quasi_newton.cpp
@@ -40,10 +40,10 @@ struct quasi_newton_aux {
     }
 };
 
-void quasi_newton::operator()(model& m, const precalculate_byatom& p, const igrid& ig, output_type& out, change& g, const vec& v, sz& evalcount) const { // g must have correct size
+void quasi_newton::operator()(model& m, const precalculate_byatom& p, const igrid& ig, output_type& out, change& g, const vec& v, stats& statcount) const { // g must have correct size
     quasi_newton_aux aux(&m, &p, &ig, v);
 
-    fl res = bfgs(aux, out.c, g, max_steps, average_required_improvement, 10, evalcount);
+    fl res = bfgs(aux, out.c, g, max_steps, average_required_improvement, 10, statcount);
 
     // Update model a last time after optimization
     m.set(out.c);

--- a/src/lib/quasi_newton.h
+++ b/src/lib/quasi_newton.h
@@ -30,7 +30,7 @@ struct quasi_newton {
     fl average_required_improvement;
     quasi_newton() : max_steps(1000), average_required_improvement(0.0) {}
     // clean up
-    void operator()(model& m, const precalculate_byatom& p, const igrid& ig, output_type& out, change& g, const vec& v, int& evalcount) const; // g must have correct size
+    void operator()(model& m, const precalculate_byatom& p, const igrid& ig, output_type& out, change& g, const vec& v, sz& evalcount) const; // g must have correct size
 };
 
 #endif

--- a/src/lib/quasi_newton.h
+++ b/src/lib/quasi_newton.h
@@ -30,7 +30,7 @@ struct quasi_newton {
     fl average_required_improvement;
     quasi_newton() : max_steps(1000), average_required_improvement(0.0) {}
     // clean up
-    void operator()(model& m, const precalculate_byatom& p, const igrid& ig, output_type& out, change& g, const vec& v, sz& evalcount) const; // g must have correct size
+    void operator()(model& m, const precalculate_byatom& p, const igrid& ig, output_type& out, change& g, const vec& v, stats& statcount) const; // g must have correct size
 };
 
 #endif

--- a/src/lib/vina.cpp
+++ b/src/lib/vina.cpp
@@ -948,7 +948,7 @@ void Vina::global_search(const int exhaustiveness, const int n_poses, const doub
 	done(m_verbosity, 1);
 	if (m_statistics){
 		double dt = seconds_since(now);
-		std::cout << "\nFinished docking: " << evalcount << " energy evaluations took " << std::setprecision(3) << dt*1000.0 << " ms (" << dt/evalcount*1E6 << " µs/eval)\n";
+		std::cout << std::fixed << std::setprecision(3) << "\nFinished docking: " << evalcount << " energy evaluations took " << dt*1000.0 << " ms (" << dt/evalcount*1E6 << " µs/eval)\n";
 	}
 
 	// Docking post-processing and rescoring

--- a/src/lib/vina.cpp
+++ b/src/lib/vina.cpp
@@ -24,6 +24,42 @@
 #include "scoring_function.h"
 #include "precalculate.h"
 
+#ifndef _WIN32
+// Time measurement
+#include <sys/time.h>
+typedef timeval current_time;
+#else
+#include "profileapi.h"
+typedef LARGE_INTEGER current_time;
+#endif
+
+template<typename T>
+inline double seconds_since(T& time_start)
+{
+#ifndef _WIN32
+	current_time time_end;
+	gettimeofday(&time_end,NULL);
+	double num_sec     = time_end.tv_sec  - time_start.tv_sec;
+	double num_usec    = time_end.tv_usec - time_start.tv_usec;
+	return (num_sec + (num_usec/1000000));
+#else
+	LARGE_INTEGER time_end, freq;
+	QueryPerformanceFrequency(&freq);
+	QueryPerformanceCounter(&time_end);
+	return (double)(time_end.QuadPart - time_start.QuadPart) / (double)freq.QuadPart;
+#endif
+}
+
+template<typename T>
+inline void start_timer(T& time_start)
+{
+#ifndef _WIN32
+	gettimeofday(&time_start,NULL);
+#else
+	QueryPerformanceCounter(&time_start);
+#endif
+}
+
 
 void Vina::cite() {
 	const std::string cite_message = "\
@@ -787,7 +823,6 @@ std::vector<double> Vina::optimize(output_type& out, int max_steps) {
 	const vec authentic_v(1000, 1000, 1000);
 	std::vector<double> energies_before_opt;
 	std::vector<double> energies_after_opt;
-	int evalcount = 0;
 
 	// Define the number minimization steps based on the number moving atoms
 	if (max_steps == 0) {
@@ -902,12 +937,18 @@ void Vina::global_search(const int exhaustiveness, const int n_poses, const doub
 	// Docking search
 	sstm << "Performing docking (random seed: " << m_seed << ")";
 	doing(sstm.str(), m_verbosity, 0);
+	current_time now;
+	start_timer(now);
 	if (m_sf_choice == SF_VINA || m_sf_choice == SF_VINARDO) {
-		parallelmc(m_model, poses, m_precalculated_byatom,    m_grid, m_grid.corner1(), m_grid.corner2(), generator, m_progress_callback);
+		parallelmc(m_model, poses, m_precalculated_byatom,    m_grid, m_grid.corner1(), m_grid.corner2(), generator, evalcount, m_progress_callback);
 	} else {
-		parallelmc(m_model, poses, m_precalculated_byatom, m_ad4grid, m_ad4grid.corner1(), m_ad4grid.corner2(), generator, m_progress_callback);
+		parallelmc(m_model, poses, m_precalculated_byatom, m_ad4grid, m_ad4grid.corner1(), m_ad4grid.corner2(), generator, evalcount, m_progress_callback);
 	}
 	done(m_verbosity, 1);
+	if (m_statistics){
+		double dt = seconds_since(now);
+		std::cout << "Finished docking: " << evalcount << " energy evaluations took " << std::setprecision(3) << dt << " s (" << dt/evalcount*1E6 << " µs/eval)\n";
+	}
 
 	// Docking post-processing and rescoring
 	poses = remove_redundant(poses, min_rmsd);
@@ -922,7 +963,6 @@ void Vina::global_search(const int exhaustiveness, const int n_poses, const doub
 				quasi_newton quasi_newton_par;
 				//std::vector<double> energies_before_opt;
 				//std::vector<double> energies_after_opt;
-				int evalcount = 0;
 				const fl slope = 1e6;
 				m_non_cache.slope = slope;
 				quasi_newton_par.max_steps = unsigned((25 + m_model.num_movable_atoms()) / 3);

--- a/src/lib/vina.cpp
+++ b/src/lib/vina.cpp
@@ -842,12 +842,12 @@ std::vector<double> Vina::optimize(output_type& out, int max_steps) {
 	// Try 5 five times to optimize locally the conformation
 	VINA_FOR(p, 5) {
 		if (m_sf_choice == SF_VINA || m_sf_choice == SF_VINARDO) {
-			quasi_newton_par(m_model, m_precalculated_byatom, m_grid,    out, g, authentic_v, evalcount);
+			quasi_newton_par(m_model, m_precalculated_byatom, m_grid,    out, g, authentic_v, statcount);
 			// Break if we succeed to bring (back) the ligand within the grid
 			if (m_grid.is_in_grid(m_model))
 				break;
 		} else {
-			quasi_newton_par(m_model, m_precalculated_byatom, m_ad4grid, out, g, authentic_v, evalcount);
+			quasi_newton_par(m_model, m_precalculated_byatom, m_ad4grid, out, g, authentic_v, statcount);
 			if (m_ad4grid.is_in_grid(m_model))
 				break;
 		}
@@ -936,19 +936,25 @@ void Vina::global_search(const int exhaustiveness, const int n_poses, const doub
 
 	// Docking search
 	sstm << "Performing docking (random seed: " << m_seed << ")";
-	evalcount = 0;
+	statcount.reset();
 	doing(sstm.str(), m_verbosity, 0);
 	current_time now;
 	start_timer(now);
 	if (m_sf_choice == SF_VINA || m_sf_choice == SF_VINARDO) {
-		parallelmc(m_model, poses, m_precalculated_byatom,    m_grid, m_grid.corner1(), m_grid.corner2(), generator, evalcount, m_progress_callback);
+		parallelmc(m_model, poses, m_precalculated_byatom,    m_grid, m_grid.corner1(), m_grid.corner2(), generator, statcount, m_progress_callback);
 	} else {
-		parallelmc(m_model, poses, m_precalculated_byatom, m_ad4grid, m_ad4grid.corner1(), m_ad4grid.corner2(), generator, evalcount, m_progress_callback);
+		parallelmc(m_model, poses, m_precalculated_byatom, m_ad4grid, m_ad4grid.corner1(), m_ad4grid.corner2(), generator, statcount, m_progress_callback);
 	}
 	done(m_verbosity, 1);
 	if (m_statistics){
 		double dt = seconds_since(now);
-		std::cout << std::fixed << std::setprecision(3) << "\nFinished docking: " << evalcount << " energy evaluations took " << dt*1000.0 << " ms (" << dt/evalcount*1E6 << " µs/eval)\n";
+		// acceptance rate = nr accepted / nr tries
+		std::cout << std::fixed << std::setprecision(3) << "\nOverall acceptance rate: " << (double)(statcount[2])/((double)(statcount[1]))*100.0 << "\%\n";
+		// avg. evals per line search = nr evals - nr tries / nr line searches (each try = 1 bfgs eval before the line search evals)
+		if(statcount[3]>0) std::cout << std::fixed << std::setprecision(3) << "Average evaluations per line search: " << (double)(statcount[0]-statcount[1])/((double)(statcount[3])) << "\n";
+		// avg. evals per MC move = nr evals / nr tries
+		std::cout << std::fixed << std::setprecision(3) << "Average evaluations per MC move: " << (double)(statcount[0])/((double)(statcount[1])) << "\n";
+		std::cout << std::fixed << std::setprecision(3) << "\nFinished docking: " << statcount[0] << " energy evaluations took " << dt*1000.0 << " ms (" << dt/statcount[0]*1.0E6 << " µs/eval)\n";
 	}
 
 	// Docking post-processing and rescoring
@@ -971,7 +977,7 @@ void Vina::global_search(const int exhaustiveness, const int n_poses, const doub
 				VINA_FOR_IN(i, poses){
 					VINA_FOR(p, 5){
 						m_non_cache.slope = 100 * std::pow(10.0, 2.0*p);
-						quasi_newton_par(m_model, m_precalculated_byatom, m_non_cache, poses[i], g, authentic_v, evalcount);
+						quasi_newton_par(m_model, m_precalculated_byatom, m_non_cache, poses[i], g, authentic_v, statcount);
 						if(m_non_cache.within(m_model))
 							break;
 					}

--- a/src/lib/vina.cpp
+++ b/src/lib/vina.cpp
@@ -947,7 +947,7 @@ void Vina::global_search(const int exhaustiveness, const int n_poses, const doub
 	done(m_verbosity, 1);
 	if (m_statistics){
 		double dt = seconds_since(now);
-		std::cout << "Finished docking: " << evalcount << " energy evaluations took " << std::setprecision(3) << dt << " s (" << dt/evalcount*1E6 << " µs/eval)\n";
+		std::cout << "\nFinished docking: " << evalcount << " energy evaluations took " << std::setprecision(3) << dt << " s (" << dt/evalcount*1E6 << " µs/eval)\n";
 	}
 
 	// Docking post-processing and rescoring

--- a/src/lib/vina.cpp
+++ b/src/lib/vina.cpp
@@ -936,6 +936,7 @@ void Vina::global_search(const int exhaustiveness, const int n_poses, const doub
 
 	// Docking search
 	sstm << "Performing docking (random seed: " << m_seed << ")";
+	evalcount = 0;
 	doing(sstm.str(), m_verbosity, 0);
 	current_time now;
 	start_timer(now);
@@ -947,7 +948,7 @@ void Vina::global_search(const int exhaustiveness, const int n_poses, const doub
 	done(m_verbosity, 1);
 	if (m_statistics){
 		double dt = seconds_since(now);
-		std::cout << "\nFinished docking: " << evalcount << " energy evaluations took " << std::setprecision(3) << dt << " s (" << dt/evalcount*1E6 << " µs/eval)\n";
+		std::cout << "\nFinished docking: " << evalcount << " energy evaluations took " << std::setprecision(3) << dt*1000.0 << " ms (" << dt/evalcount*1E6 << " µs/eval)\n";
 	}
 
 	// Docking post-processing and rescoring

--- a/src/lib/vina.h
+++ b/src/lib/vina.h
@@ -113,7 +113,6 @@ public:
 
 	void cite();
 	int seed() { return m_seed; }
-	sz nr_evals() { return evalcount; }
 	void set_receptor(const std::string &rigid_name=std::string(), const std::string &flex_name=std::string());
 	void set_ligand_from_string(const std::string &ligand_string);
 	void set_ligand_from_string(const std::vector<std::string> &ligand_string);
@@ -177,7 +176,7 @@ private:
 	int m_verbosity;
 	bool m_no_refine;
 	bool m_statistics;
-	sz evalcount = 0;
+	stats statcount;
 	
 	std::function<void(double)>* m_progress_callback;
 

--- a/src/lib/vina.h
+++ b/src/lib/vina.h
@@ -23,6 +23,7 @@
 #ifndef VINA_H
 #define VINA_H
 
+#include <iomanip>
 #include <iostream>
 #include <string>
 #include <stdlib.h>
@@ -70,19 +71,19 @@ private:
 class Vina {
 public:
 	// Constructor
-	Vina(const std::string &sf_name="vina", int cpu=0, int seed=0, int verbosity=1, bool no_refine=false, std::function<void(double)>* progress_callback = NULL) {
+	Vina(const std::string &sf_name="vina", int cpu=0, int seed=0, int verbosity=1, bool no_refine=false, bool statistics=false, std::function<void(double)>* progress_callback = NULL) {
 		m_verbosity = verbosity;
 		m_receptor_initialized = false;
 		m_ligand_initialized = false;
 		m_map_initialized = false;
 		m_seed = generate_seed(seed);
 		m_no_refine = no_refine;
+		m_statistics = statistics;
 		m_progress_callback = progress_callback;
 
 		// Look for the number of cpu
 		if (cpu <= 0) {
 			unsigned num_cpus = boost::thread::hardware_concurrency();
-
 			if (num_cpus > 0) {
 				m_cpu = num_cpus;
 			} else {
@@ -93,7 +94,6 @@ public:
 		} else {
 			m_cpu = cpu;
 		}
-
 		if (sf_name.compare("vina") == 0) {
 			m_sf_choice = SF_VINA;
 			set_vina_weights();
@@ -113,6 +113,7 @@ public:
 
 	void cite();
 	int seed() { return m_seed; }
+	sz nr_evals() { return evalcount; }
 	void set_receptor(const std::string &rigid_name=std::string(), const std::string &flex_name=std::string());
 	void set_ligand_from_string(const std::string &ligand_string);
 	void set_ligand_from_string(const std::vector<std::string> &ligand_string);
@@ -121,20 +122,20 @@ public:
 	//void set_ligand(OpenBabel::OBMol* mol);
 	//void set_ligand(std::vector<OpenBabel::OBMol*> mol);
 	void set_vina_weights(double weight_gauss1=-0.035579, double weight_gauss2=-0.005156,
-						       double weight_repulsion=0.840245, double weight_hydrophobic=-0.035069,
-						       double weight_hydrogen=-0.587439, double weight_glue=50,
-						       double weight_rot=0.05846);
+	                      double weight_repulsion=0.840245, double weight_hydrophobic=-0.035069,
+	                      double weight_hydrogen=-0.587439, double weight_glue=50,
+	                      double weight_rot=0.05846);
 	void set_vinardo_weights(double weight_gauss1=-0.045,
-							       double weight_repulsion=0.8, double weight_hydrophobic=-0.035,
-							       double weight_hydrogen=-0.600, double weight_glue=50,
-							       double weight_rot=0.05846);
+	                         double weight_repulsion=0.8, double weight_hydrophobic=-0.035,
+	                         double weight_hydrogen=-0.600, double weight_glue=50,
+	                         double weight_rot=0.05846);
 	void set_ad4_weights(double weight_ad4_vdw=0.1662, double weight_ad4_hb=0.1209,
-						      double weight_ad4_elec=0.1406, double weight_ad4_dsolv=0.1322,
-						      double weight_glue=50, double weight_ad4_rot=0.2983);
+	                     double weight_ad4_elec=0.1406, double weight_ad4_dsolv=0.1322,
+	                     double weight_glue=50, double weight_ad4_rot=0.2983);
 	std::vector<double> grid_dimensions_from_ligand(double buffer_size=4);
 	void compute_vina_maps(double center_x, double center_y, double center_z,
-								  double size_x, double size_y, double size_z,
-								  double granularity=0.5, bool force_even_voxels=false);
+	                       double size_x, double size_y, double size_z,
+	                       double granularity=0.5, bool force_even_voxels=false);
 	void load_maps(std::string maps);
 	void randomize(const int max_steps=10000);
 	std::vector<double> score();
@@ -147,7 +148,7 @@ public:
 	void write_pose(const std::string &output_name, const std::string &remark = std::string());
 	void write_poses(const std::string &output_name, int how_many=9, double energy_range=3.0);
 	void write_maps(const std::string& map_prefix="receptor", const std::string& gpf_filename="NULL",
-					    const std::string& fld_filename="NULL", const std::string& receptor_filename="NULL");
+	                const std::string& fld_filename="NULL", const std::string& receptor_filename="NULL");
 	void show_score(const std::vector<double> energies);
 
 private:
@@ -175,6 +176,9 @@ private:
 	// others
 	int m_verbosity;
 	bool m_no_refine;
+	bool m_statistics;
+	sz evalcount = 0;
+	
 	std::function<void(double)>* m_progress_callback;
 
 	std::string vina_remarks(output_type& pose, fl lb, fl ub);

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -130,6 +130,7 @@ Thank you!\n";
 		int seed = 0;
 		int exhaustiveness = 8;
 		int max_evals = 0;
+		bool statistics = false;
 		int verbosity = 1;
 		int num_modes = 9;
 		double min_rmsd = 1.0;
@@ -242,6 +243,7 @@ Thank you!\n";
 			("min_rmsd", value<double>(&min_rmsd)->default_value(1.0), "minimum RMSD between output poses")
 			("energy_range", value<double>(&energy_range)->default_value(3.0), "maximum energy difference between the best binding mode and the worst one displayed (kcal/mol)")
 			("spacing", value<double>(&grid_spacing)->default_value(0.375), "grid spacing (Angstrom)")
+			("statistics", value<bool>(&statistics)->default_value(false), "output runtime statistics")
 			("verbosity", value<int>(&verbosity)->default_value(1), "verbosity (0=no output, 1=normal, 2=verbose)")
 		;
 		options_description config("Configuration file (optional)");
@@ -390,7 +392,7 @@ Thank you!\n";
 			std::cout << "\n";
 		}
 
-		Vina v(sf_name, cpu, seed, verbosity, no_refine);
+		Vina v(sf_name, cpu, seed, verbosity, no_refine, statistics);
 
 		// rigid_name variable can be ignored for AD4
 		if (vm.count("receptor") || vm.count("flex"))


### PR DESCRIPTION
This PR adds the (boolean) option `--statistics` which enables output of docking runtime statistics such as these:
```
Overall acceptance rate: 50.677%
Average evaluations per line search: 3.290
Average evaluations per MC move: 76.875

Finished docking: 17112412 energy evaluations took 14758.118 ms (0.862 µs/eval)
```
